### PR TITLE
Feature irrelevant constraint order

### DIFF
--- a/benchmark/killer_sudoku/cs.jl
+++ b/benchmark/killer_sudoku/cs.jl
@@ -26,18 +26,17 @@ function solve_all(filenames; benchmark=false, single_times=true)
         grid = zeros(Int, (9,9))
 
         com_grid = create_sudoku_grid!(com, grid)
-
+        
+        add_sudoku_constr!(com, com_grid)
         for s in sums
             add_constraint!(com, sum([com_grid[CartesianIndex(ind)] for ind in s.indices]) == s.result)
             # add_constraint!(com, CS.all_different([com_grid[CartesianIndex(ind)] for ind in s.indices]))
         end
 
-        add_sudoku_constr!(com, com_grid)
-
         if single_times
             GC.enable(false)
             t = time()
-            status = solve!(com);
+            status = solve!(com; backtrack=true);
             t = time()-t
             GC.enable(true)
             println(i-1,", ", t)
@@ -51,6 +50,8 @@ function solve_all(filenames; benchmark=false, single_times=true)
             println("Status: ", status)
             @assert fulfills_sudoku_constr(com_grid)
         end
+        com = nothing
+        GC.gc()
     end
     println("")
     tt = time()-ct

--- a/benchmark/sudoku/cs.jl
+++ b/benchmark/sudoku/cs.jl
@@ -62,7 +62,7 @@ function solve_one(grid)
 end
 
 function main(; benchmark=false, single_times=true)
-    solve_all(from_file("benchmark/sudoku/data/top95.txt"); benchmark=benchmark, single_times=single_times)
+    solve_all(from_file("data/top95.txt"); benchmark=benchmark, single_times=single_times)
     # solve_all(from_file("hardest.txt"), "hardest")
 end
 

--- a/src/ConstraintSolver.jl
+++ b/src/ConstraintSolver.jl
@@ -388,7 +388,7 @@ function prune!(com::CS.CoM; pre_backtrack=false, all=false, only_once=false, in
         # will be changed or b_open_constraint => false
         open_pos, ci = find_best_constraint(com, constraint_idxs_vec)
         # no open values => don't need to call again
-        if open_pos == 0 && !initial_check && !all
+        if open_pos == 0 && !initial_check
             constraint_idxs_vec[ci] = N
             continue
         end
@@ -701,14 +701,7 @@ function backtrack!(com::CS.CoM, max_bt_steps; sorting=true)
         fix!(com, com.search_space[ind], pval)
         com.info.backtrack_fixes   += 1
 
-        feasible = prune!(com; all=true, only_once=true)
-    
-        if !feasible
-            com.info.backtrack_reverses += 1
-            continue
-        end
-
-        # prune on changed values
+        # prune completely start with all that changed by the fix
         feasible = prune!(com)
          
         if !feasible

--- a/src/ConstraintSolver.jl
+++ b/src/ConstraintSolver.jl
@@ -43,6 +43,7 @@ mutable struct BasicConstraint <: Constraint
     fct                 :: Function
     indices             :: Vector{Int}
     pvals               :: Vector{Int}
+    hash                :: UInt64
     BasicConstraint() = new()
 end
 
@@ -64,6 +65,7 @@ mutable struct LinearConstraint <: Constraint
     maxs                :: Vector{Int}
     pre_mins            :: Vector{Int}
     pre_maxs            :: Vector{Int}
+    hash                :: UInt64
     LinearConstraint() = new()
 end
 
@@ -115,6 +117,7 @@ end
 
 include("printing.jl")
 include("logs.jl")
+include("hashes.jl")
 include("Variable.jl")
 include("objective.jl")
 include("linearcombination.jl")
@@ -337,23 +340,39 @@ function open_possibilities(search_space, indices)
     return open
 end
 
+function find_best_constraint(com::CS.CoM, constraint_idxs_vec)
+    best_ci = 0
+    best_open = typemax(Int64)
+    best_hash = typemax(UInt64)
+    for ci = 1:length(constraint_idxs_vec)
+        if constraint_idxs_vec[ci] <= best_open
+            if constraint_idxs_vec[ci] < best_open || com.constraints[ci].hash < best_hash
+                best_ci = ci
+                best_open = constraint_idxs_vec[ci]
+                best_hash = com.constraints[ci].hash
+            end
+        end
+    end
+    return best_open, best_ci
+end
+
 """
     prune!(com::CS.CoM; pre_backtrack=false)
 
 Prune based on changes by initial solve or backtracking. The information for it is stored in each variable
 Returns whether it's still feasible
 """
-function prune!(com::CS.CoM; pre_backtrack=false)
+function prune!(com::CS.CoM; pre_backtrack=false, all=false, only_once=false, initial_check=false)
     feasible = true
-    N = 10000
+    N = typemax(Int64)
     search_space = com.search_space
     prev_var_length = zeros(Int, length(search_space))
-    constraint_idxs_vec = N .* ones(Int, length(com.constraints))
+    constraint_idxs_vec = fill(N, length(com.constraints))
     # get all constraints which need to be called (only once)
     current_backtrack_id = com.c_backtrack_idx
     for var in search_space
         new_var_length = length(var.changes[current_backtrack_id])
-        if new_var_length > 0
+        if new_var_length > 0 || all || initial_check
             prev_var_length[var.idx] = new_var_length
             inner_constraints = com.constraints[com.subscription[var.idx]]
             for ci in com.subscription[var.idx]
@@ -367,11 +386,13 @@ function prune!(com::CS.CoM; pre_backtrack=false)
     while true
         b_open_constraint = false
         # will be changed or b_open_constraint => false
-        open_pos, ci = findmin(constraint_idxs_vec)
-        if open_pos == 0
+        open_pos, ci = find_best_constraint(com, constraint_idxs_vec)
+        # no open values => don't need to call again
+        if open_pos == 0 && !initial_check && !all
             constraint_idxs_vec[ci] = N
             continue
         end
+        # checked all
         if open_pos == N
             break
         end
@@ -399,6 +420,10 @@ function prune!(com::CS.CoM; pre_backtrack=false)
                 for ci in com.subscription[var.idx]
                     if ci != constraint.idx
                         inner_constraint = com.constraints[ci]
+                        # if initial check or don't add constraints => update only those which already have open possibilities
+                        if (only_once || initial_check) && constraint_idxs_vec[inner_constraint.idx] == N
+                            continue
+                        end
                         constraint_idxs_vec[inner_constraint.idx] = open_possibilities(search_space, inner_constraint.indices)
                     end
                 end
@@ -674,14 +699,10 @@ function backtrack!(com::CS.CoM, max_bt_steps; sorting=true)
         end
         # value is still possible => set it
         fix!(com, com.search_space[ind], pval)
+        com.info.backtrack_fixes   += 1
 
-        for constraint in constraints
-            feasible = constraint.fct(com, constraint; logs = false)
-            if !feasible
-                feasible = false
-                break
-            end
-        end
+        feasible = prune!(com; all=true, only_once=true)
+    
         if !feasible
             com.info.backtrack_reverses += 1
             continue
@@ -718,11 +739,11 @@ function backtrack!(com::CS.CoM, max_bt_steps; sorting=true)
             end
         end
 
-        if com.info.backtrack_fixes + 1 > max_bt_steps
+        if com.info.backtrack_fixes > max_bt_steps
             return :NotSolved
         end
 
-        com.info.backtrack_fixes   += 1
+        
 
         if com.input[:logs]
             com.logs[backtrack_obj.idx] = log_one_node(com, length(com.search_space), backtrack_obj.idx, step_nr)
@@ -902,20 +923,11 @@ function solve!(com::CS.CoM; backtrack=true, max_bt_steps=typemax(Int64), backtr
     simplify!(com)
 
     # check if all feasible even if for example everything is fixed
-    feasible = true
-    for constraint in com.constraints
-        com.info.pre_backtrack_calls += 1
-        feasible = constraint.fct(com, constraint)
-        if !feasible
-            feasible = false
-            break
-        end
-    end
+    feasible = prune!(com; pre_backtrack=true, initial_check=true)
 
     if !feasible
         return :Infeasible
     end
-
     
     if all(v->isfixed(v), com.search_space)
         com.best_bound = get_best_bound(com)

--- a/src/all_different.jl
+++ b/src/all_different.jl
@@ -10,6 +10,7 @@ function all_different(variables::Vector{Variable})
     constraint = BasicConstraint()
     constraint.fct = all_different
     constraint.indices = Int[v.idx for v in variables]
+    constraint.hash = constraint_hash(constraint)
     return constraint
 end
 

--- a/src/eq_sum.jl
+++ b/src/eq_sum.jl
@@ -18,6 +18,7 @@ function Base.:(==)(x::LinearVariables, y::Int)
     lc.pre_mins = zeros(Int, length(indices))
     # this can be changed later in `set_in_all_different!` but needs to be initialized with false
     lc.in_all_different = false
+    lc.hash = constraint_hash(lc)
     return lc
 end
 

--- a/src/equal.jl
+++ b/src/equal.jl
@@ -8,6 +8,7 @@ function equal(variables::Vector{Variable})
     constraint = BasicConstraint()
     constraint.fct = equal
     constraint.indices = Int[v.idx for v in variables]
+    constraint.hash = constraint_hash(constraint)
     return constraint
 end
 
@@ -21,6 +22,7 @@ function Base.:(==)(x::Variable, y::Variable)
     bc = BasicConstraint()
     bc.fct = equal
     bc.indices = Int[x.idx, y.idx]
+    bc.hash = constraint_hash(bc)
     return bc
 end
 

--- a/src/hashes.jl
+++ b/src/hashes.jl
@@ -1,0 +1,7 @@
+function constraint_hash(constraint::BasicConstraint)
+    return hash([constraint.fct, constraint.indices])
+end
+
+function constraint_hash(constraint::LinearConstraint)
+    return hash([constraint.fct, constraint.indices, constraint.coeffs, constraint.operator, constraint.rhs])
+end


### PR DESCRIPTION
Currently the order constraints get added are relevant.
This constraints changes that as it is unexpected behavior.
Additionally there are some added parameters for `prune!`:
- `all` => use all constraints for the first run
- `only_once` => don't continue pruning after first run
- `initial_check` => checks if feasible even if all values are set 
