### PR TITLE
use MOI for benchmark tests for better comparison

### DIFF
--- a/benchmark/sudoku/cs.jl
+++ b/benchmark/sudoku/cs.jl
@@ -1,6 +1,8 @@
-using ConstraintSolver, JuMP
+using ConstraintSolver, MathOptInterface
 
-CS = ConstraintSolver
+const CS = ConstraintSolver
+const MOI = MathOptInterface
+const MOIU = MOI.Utilities
 include("../../test/sudoku_fcts.jl")
 
 function from_file(filename, sep='\n')
@@ -22,35 +24,46 @@ function solve_all(grids; benchmark=false, single_times=true)
     ct = time()
     grids = grids
     for (i,grid) in enumerate(grids)
-        m = Model(with_optimizer(CS.Optimizer))
-        @variable(m, 1 <= x[1:9,1:9] <= 9, Int)
+        m = CS.Optimizer()
+        
+        x = [[MOI.add_constrained_variable(m, MOI.Integer()) for i=1:9] for j=1:9]
+        for r=1:9, c=1:9
+            MOI.add_constraint(m, x[r][c][1], MOI.GreaterThan(1.0))
+            MOI.add_constraint(m, x[r][c][1], MOI.LessThan(9.0))
+        end
+
         # set variables
         for r=1:9, c=1:9
             if grid[r,c] != 0
-                @constraint(m, x[r,c] == grid[r,c])
+                sat = [MOI.ScalarAffineTerm(1.0, x[r][c][1])]
+                MOI.add_constraint(m, MOI.ScalarAffineFunction{Float64}(sat, 0.0), MOI.EqualTo(convert(Float64,grid[r,c])))
             end
         end
         # sudoku constraints
-        jump_add_sudoku_constr!(m, x)
+        moi_add_sudoku_constr!(m, x)
 
         if single_times
             GC.enable(false)
             t = time()
-            optimize!(m)
-            status = JuMP.termination_status(m)
+            MOI.optimize!(m)
+            status = MOI.get(m, MOI.TerminationStatus())
             t = time()-t
             GC.enable(true)
             println(i-1,", ", t)
         else
             GC.enable(false)
-            optimize!(m)
-            status = JuMP.termination_status(m)
+            MOI.optimize!(m)
+            status = MOI.get(m, MOI.TerminationStatus())
             GC.enable(true)
         end
         if !benchmark
-            @show JuMP.backend(m).optimizer.model.inner.info
+            @show m.inner.info
             println("Status: ", status)
-            @assert jump_fulfills_sudoku_constr(JuMP.value.(x))
+            solution = zeros(Int, 9, 9)
+            for r=1:9
+                solution[r,:] = [MOI.get(m, MOI.VariablePrimal(), x[r][c][1]) for c=1:9]
+            end
+            @assert jump_fulfills_sudoku_constr(solution)
         end
     end
     println("")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,6 +5,7 @@ using MathOptInterface, JuMP
 
 const MOI = MathOptInterface
 const CS = ConstraintSolver
+const MOIU = MOI.Utilities
 
 include("fct_tests.jl")
 include("moi.jl")

--- a/test/sudoku_fcts.jl
+++ b/test/sudoku_fcts.jl
@@ -1,5 +1,3 @@
-using ConstraintSolver
-CS = ConstraintSolver
 
 function sudokus_from_file(filename, sep='\n')
     s = open(filename) do file
@@ -57,6 +55,26 @@ function jump_add_sudoku_constr!(m, x)
     for br=0:2
         for bc=0:2
             @constraint(m, vec(x[br*3+1:(br+1)*3,bc*3+1:(bc+1)*3]) in CS.AllDifferentSet(9))
+        end
+    end
+end
+
+function moi_add_sudoku_constr!(m, x)
+    for r = 1:9
+        MOI.add_constraint(m, MOI.VectorOfVariables([x[r][c][1] for c =1:9]), CS.AllDifferentSet(9))
+    end
+    for c = 1:9
+        MOI.add_constraint(m, MOI.VectorOfVariables([x[r][c][1] for r =1:9]), CS.AllDifferentSet(9))
+    end
+    variables = [MOI.VariableIndex(0) for _ = 1:9]
+    for br=0:2
+        for bc=0:2
+            variables_i = 1
+            for i=br*3+1:(br+1)*3, j=bc*3+1:(bc+1)*3
+                variables[variables_i] = x[i][j][1]
+                variables_i += 1
+            end
+            MOI.add_constraint(m, variables, CS.AllDifferentSet(9))
         end
     end
 end


### PR DESCRIPTION
It turned out that the ordering of the indices in constraints are somehow not regular in the JuMP version which makes it hard to compare directly between two different branches whether something changed. 
This PR implements (Killer)sudoku using MOI instead of JuMP because there the indices should always be the same and therefore the hash of the constraint and the order in pruning steps. 
Important to check the benchmark of #58 