### PR TITLE
use constraint internals and `std`

### DIFF
--- a/src/ConstraintSolver.jl
+++ b/src/ConstraintSolver.jl
@@ -103,7 +103,7 @@ function fulfills_constraints(com::CS.CoM, index, value)
     for ci in com.subscription[index]
         constraint = com.constraints[ci]
         feasible =
-            still_feasible(com, constraint, constraint.fct, constraint.set, value, index)
+            still_feasible(com, constraint, constraint.std.fct, constraint.std.set, value, index)
         if !feasible
             break
         end
@@ -114,10 +114,10 @@ end
 """
     set_pvals!(com::CS.CoM, constraint::Constraint)
 
-Compute the possible values inside this constraint and set it as constraint.pvals
+Compute the possible values inside this constraint and set it as constraint.std.pvals
 """
 function set_pvals!(com::CS.CoM, constraint::Constraint)
-    indices = constraint.indices
+    indices = constraint.std.indices
     variables = Variable[v for v in com.search_space[indices]]
     pvals_intervals = Vector{NamedTuple}()
     push!(pvals_intervals, (from = variables[1].lower_bound, to = variables[1].upper_bound))
@@ -144,7 +144,7 @@ function set_pvals!(com::CS.CoM, constraint::Constraint)
     for interval in pvals_intervals[2:end]
         pvals = vcat(pvals, collect(interval.from:interval.to))
     end
-    constraint.pvals = pvals
+    constraint.std.pvals = pvals
 end
 
 """
@@ -153,11 +153,11 @@ end
 Add a constraint to the model i.e `add_constraint!(com, a != b)`
 """
 function add_constraint!(com::CS.CoM, constraint::Constraint)
-    constraint.idx = length(com.constraints) + 1
+    constraint.std.idx = length(com.constraints) + 1
     push!(com.constraints, constraint)
     set_pvals!(com, constraint)
-    for (i, ind) in enumerate(constraint.indices)
-        push!(com.subscription[ind], constraint.idx)
+    for (i, ind) in enumerate(constraint.std.indices)
+        push!(com.subscription[ind], constraint.std.idx)
     end
 end
 
@@ -218,10 +218,10 @@ function get_next_prune_constraint(com::CS.CoM, constraint_idxs_vec)
     best_hash = typemax(UInt64)
     for ci = 1:length(constraint_idxs_vec)
         if constraint_idxs_vec[ci] <= best_open
-            if constraint_idxs_vec[ci] < best_open || com.constraints[ci].hash < best_hash
+            if constraint_idxs_vec[ci] < best_open || com.constraints[ci].std.hash < best_hash
                 best_ci = ci
                 best_open = constraint_idxs_vec[ci]
-                best_hash = com.constraints[ci].hash
+                best_hash = com.constraints[ci].std.hash
             end
         end
     end
@@ -260,8 +260,8 @@ function prune!(
             prev_var_length[var.idx] = new_var_length
             for ci in com.subscription[var.idx]
                 inner_constraint = com.constraints[ci]
-                constraint_idxs_vec[inner_constraint.idx] =
-                    open_possibilities(search_space, inner_constraint.indices)
+                constraint_idxs_vec[inner_constraint.std.idx] =
+                    open_possibilities(search_space, inner_constraint.std.indices)
             end
         end
     end
@@ -284,7 +284,7 @@ function prune!(
         constraint = com.constraints[ci]
 
         feasible =
-            prune_constraint!(com, constraint, constraint.fct, constraint.set; logs = false)
+            prune_constraint!(com, constraint, constraint.std.fct, constraint.std.set; logs = false)
         if !pre_backtrack
             com.info.in_backtrack_calls += 1
         else
@@ -296,21 +296,21 @@ function prune!(
         end
 
         # if we changed another variable increase the level of the constraints to call them later
-        for var_idx in constraint.indices
+        for var_idx in constraint.std.indices
             var = search_space[var_idx]
             new_var_length = length(var.changes[current_backtrack_id])
             if new_var_length > prev_var_length[var.idx]
                 prev_var_length[var.idx] = new_var_length
                 for ci in com.subscription[var.idx]
-                    if ci != constraint.idx
+                    if ci != constraint.std.idx
                         inner_constraint = com.constraints[ci]
                         # if initial check or don't add constraints => update only those which already have open possibilities
                         if (only_once || initial_check) &&
-                           constraint_idxs_vec[inner_constraint.idx] == N
+                           constraint_idxs_vec[inner_constraint.std.idx] == N
                             continue
                         end
-                        constraint_idxs_vec[inner_constraint.idx] =
-                            open_possibilities(search_space, inner_constraint.indices)
+                        constraint_idxs_vec[inner_constraint.std.idx] =
+                            open_possibilities(search_space, inner_constraint.std.indices)
                     end
                 end
             end
@@ -461,7 +461,7 @@ function update_best_bound!(backtrack_obj::BacktrackObj, com::CS.CoM, constraint
     for constraint in constraints
         relevant = false
         for obj_index in com.objective.indices
-            if obj_index in constraint.indices
+            if obj_index in constraint.std.indices
                 relevant = true
                 break
             end
@@ -470,8 +470,8 @@ function update_best_bound!(backtrack_obj::BacktrackObj, com::CS.CoM, constraint
             feasible = prune_constraint!(
                 com,
                 constraint,
-                constraint.fct,
-                constraint.set;
+                constraint.std.fct,
+                constraint.std.set;
                 logs = false,
             )
             if !feasible
@@ -890,12 +890,12 @@ function simplify!(com)
     b_all_different_sum = false
     b_eq_sum = false
     for constraint in com.constraints
-        if isa(constraint.set, AllDifferentSetInternal)
+        if isa(constraint.std.set, AllDifferentSetInternal)
             b_all_different = true
-            if length(constraint.indices) == length(constraint.pvals)
+            if length(constraint.std.indices) == length(constraint.std.pvals)
                 b_all_different_sum = true
             end
-        elseif isa(constraint.fct, SAF) && isa(constraint.set, MOI.EqualTo)
+        elseif isa(constraint.std.fct, SAF) && isa(constraint.std.set, MOI.EqualTo)
             b_eq_sum = true
         end
     end
@@ -909,24 +909,24 @@ function simplify!(com)
         for constraint_idx = 1:length(com.constraints)
             constraint = com.constraints[constraint_idx]
 
-            if isa(constraint.set, AllDifferentSetInternal)
+            if isa(constraint.std.set, AllDifferentSetInternal)
                 add_sum_constraint = true
-                if length(constraint.indices) == length(constraint.pvals)
-                    all_diff_sum = sum(constraint.pvals)
+                if length(constraint.std.indices) == length(constraint.std.pvals)
+                    all_diff_sum = sum(constraint.std.pvals)
                     # check if some sum constraints are completely inside this alldifferent constraint
                     in_sum = 0
                     found_possible_constraint = false
-                    outside_indices = constraint.indices
+                    outside_indices = constraint.std.indices
                     for sc_idx in constraint.sub_constraint_idxs
                         sub_constraint = com.constraints[sc_idx]
-                        if isa(sub_constraint.fct, SAF) &&
-                            isa(sub_constraint.set, MOI.EqualTo)
+                        if isa(sub_constraint.std.fct, SAF) &&
+                            isa(sub_constraint.std.set, MOI.EqualTo)
                             # the coefficients must be all 1
-                            if all(t.coefficient == 1 for t in sub_constraint.fct.terms)
+                            if all(t.coefficient == 1 for t in sub_constraint.std.fct.terms)
                                 found_possible_constraint = true
-                                in_sum += sub_constraint.set.value -
-                                    sub_constraint.fct.constant
-                                outside_indices = setdiff(outside_indices, sub_constraint.indices)
+                                in_sum += sub_constraint.std.set.value -
+                                    sub_constraint.std.fct.constant
+                                outside_indices = setdiff(outside_indices, sub_constraint.std.indices)
                             end
                         end
                     end
@@ -941,7 +941,7 @@ function simplify!(com)
 
                     total_sum = 0
                     outside_indices = Int[]
-                    cons_indices_dict = arr2dict(constraint.indices)
+                    cons_indices_dict = arr2dict(constraint.std.indices)
                     for variable_idx in keys(cons_indices_dict)
                         found_sum_constraint = false
                         for sub_constraint_idx in com.subscription[variable_idx]
@@ -951,15 +951,15 @@ function simplify!(com)
                             end
                             sub_constraint = com.constraints[sub_constraint_idx]
                             # it must be an equal constraint and all coefficients must be 1 otherwise we can't add a constraint
-                            if isa(sub_constraint.fct, SAF) &&
-                               isa(sub_constraint.set, MOI.EqualTo)
-                                if all(t.coefficient == 1 for t in sub_constraint.fct.terms)
+                            if isa(sub_constraint.std.fct, SAF) &&
+                               isa(sub_constraint.std.set, MOI.EqualTo)
+                                if all(t.coefficient == 1 for t in sub_constraint.std.fct.terms)
                                     found_sum_constraint = true
                                     total_sum +=
-                                        sub_constraint.set.value -
-                                        sub_constraint.fct.constant
+                                        sub_constraint.std.set.value -
+                                        sub_constraint.std.fct.constant
                                     all_inside = true
-                                    for sub_variable_idx in sub_constraint.indices
+                                    for sub_variable_idx in sub_constraint.std.indices
                                         if !haskey(cons_indices_dict, sub_variable_idx)
                                             all_inside = false
                                             push!(outside_indices, sub_variable_idx)
@@ -1003,13 +1003,13 @@ function set_in_all_different!(com::CS.CoM; constraints=com.constraints)
         if :in_all_different in fieldnames(typeof(constraint))
             if !constraint.in_all_different
                 subscriptions_idxs =
-                    [[i for i in com.subscription[v]] for v in constraint.indices]
+                    [[i for i in com.subscription[v]] for v in constraint.std.indices]
                 intersects = intersect(subscriptions_idxs...)
 
                 for i in intersects
-                    if isa(com.constraints[i].set, AllDifferentSetInternal)
+                    if isa(com.constraints[i].std.set, AllDifferentSetInternal)
                         constraint.in_all_different = true
-                        push!(com.constraints[i].sub_constraint_idxs, constraint.idx)
+                        push!(com.constraints[i].sub_constraint_idxs, constraint.std.idx)
                     end
                 end
             end

--- a/src/constraints/eq_sum.jl
+++ b/src/constraints/eq_sum.jl
@@ -11,7 +11,7 @@ function Base.:(==)(x::LinearCombination, y::Real)
     func, T = linear_combination_to_saf(LinearCombination(indices, coeffs))
     lc = LinearConstraint(func, MOI.EqualTo{T}(rhs), indices)
 
-    lc.hash = constraint_hash(lc)
+    lc.std.hash = constraint_hash(lc)
     return lc
 end
 
@@ -48,7 +48,7 @@ function prune_constraint!(
     set::MOI.EqualTo{T};
     logs = true,
 ) where {T<:Real}
-    indices = constraint.indices
+    indices = constraint.std.indices
     search_space = com.search_space
     rhs = set.value - fct.constant
 
@@ -184,7 +184,7 @@ function prune_constraint!(
             intersect_cons =
                 intersect(com.subscription[unfixed_ind_1], com.subscription[unfixed_ind_2])
             for constraint_idx in intersect_cons
-                if isa(com.constraints[constraint_idx].set, AllDifferentSetInternal)
+                if isa(com.constraints[constraint_idx].std.set, AllDifferentSetInternal)
                     is_all_different = true
                     break
                 end
@@ -262,7 +262,7 @@ function still_feasible(
     num_not_fixed = 0
     max_extra = 0
     min_extra = 0
-    for (i, idx) in enumerate(constraint.indices)
+    for (i, idx) in enumerate(constraint.std.indices)
         if idx == index
             csum += val * fct.terms[i].coefficient
             continue

--- a/src/constraints/equal.jl
+++ b/src/constraints/equal.jl
@@ -5,17 +5,16 @@ Create a BasicConstraint which will later be used by `equal(com, constraint)` \n
 Can be used i.e by `add_constraint!(com, CS.equal([x,y,z])`.
 """
 function equal(variables::Vector{Variable})
-    constraint = BasicConstraint(
+    internals = ConstraintInternals(
         0, # idx will be changed later
         var_vector_to_moi(variables),
         EqualSet(length(variables)),
-        Int[v.idx for v in variables],
-        Int[], # pvals will be filled later
-        false, # `enforce_bound` can be changed later but should be set to false by default
-        nothing, 
-        zero(UInt64), # hash will be filled in the next step
+        Int[v.idx for v in variables]
     )
-    constraint.hash = constraint_hash(constraint)
+    constraint = BasicConstraint(
+      internals
+    )
+    constraint.std.hash = constraint_hash(constraint)
     return constraint
 end
 
@@ -27,17 +26,16 @@ Can be used i.e by `add_constraint!(com, x == y)`.
 """
 function Base.:(==)(x::Variable, y::Variable)
     variables = [x, y]
-    bc = BasicConstraint(
+    internals = ConstraintInternals(
         0, # idx will be changed later
         var_vector_to_moi(variables),
         EqualSet(2),
-        Int[x.idx, y.idx],
-        Int[], # pvals will be filled later
-        false, # `enforce_bound` can be changed later but should be set to false by default
-        nothing,
-        zero(UInt64), # hash will be filled in the next step
+        Int[x.idx, y.idx]
     )
-    bc.hash = constraint_hash(bc)
+    bc = BasicConstraint(
+       internals
+    )
+    bc.std.hash = constraint_hash(bc)
     return bc
 end
 
@@ -54,7 +52,7 @@ function prune_constraint!(
     set::EqualSet;
     logs = true,
 )
-    indices = constraint.indices
+    indices = constraint.std.indices
 
     search_space = com.search_space
     # is only needed if we want to set more
@@ -122,6 +120,6 @@ function still_feasible(
     value::Int,
     index::Int,
 )
-    indices = filter(i -> i != index, constraint.indices)
+    indices = filter(i -> i != index, constraint.std.indices)
     return all(v -> issetto(v, value) || !isfixed(v), com.search_space[indices])
 end

--- a/src/constraints/less_than.jl
+++ b/src/constraints/less_than.jl
@@ -11,7 +11,7 @@ function Base.:(<=)(x::LinearCombination, y::Real)
     func, T = linear_combination_to_saf(LinearCombination(indices, coeffs))
     lc = LinearConstraint(func, MOI.LessThan{T}(rhs), indices)
 
-    lc.hash = constraint_hash(lc)
+    lc.std.hash = constraint_hash(lc)
     return lc
 end
 
@@ -62,7 +62,7 @@ function prune_constraint!(
     set::MOI.LessThan{T};
     logs = true,
 ) where {T<:Real}
-    indices = constraint.indices
+    indices = constraint.std.indices
     search_space = com.search_space
     rhs = set.upper - fct.constant
 
@@ -145,7 +145,7 @@ function still_feasible(
     rhs = set.upper - fct.constant
     min_sum = zero(T)
 
-    for (i, idx) in enumerate(constraint.indices)
+    for (i, idx) in enumerate(constraint.std.indices)
         if idx == index
             min_sum += val * fct.terms[i].coefficient
             continue

--- a/src/hashes.jl
+++ b/src/hashes.jl
@@ -1,18 +1,18 @@
 function constraint_hash(constraint::Union{AllDifferentConstraint,BasicConstraint})
-    return hash([string(typeof(constraint.set)), constraint.indices])
+    return hash([string(typeof(constraint.std.set)), constraint.std.indices])
 end
 
 function constraint_hash(constraint::LinearConstraint)
-    coeffs = [t.coefficient for t in constraint.fct.terms]
-    if isa(constraint.set, MOI.EqualTo)
-        rhs = constraint.set.value - constraint.fct.constant
+    coeffs = [t.coefficient for t in constraint.std.fct.terms]
+    if isa(constraint.std.set, MOI.EqualTo)
+        rhs = constraint.std.set.value - constraint.std.fct.constant
     end
-    if isa(constraint.set, MOI.LessThan)
-        rhs = constraint.set.upper - constraint.fct.constant
+    if isa(constraint.std.set, MOI.LessThan)
+        rhs = constraint.std.set.upper - constraint.std.fct.constant
     end
-    return hash([string(typeof(constraint.set)), constraint.indices, coeffs, rhs])
+    return hash([string(typeof(constraint.std.set)), constraint.std.indices, coeffs, rhs])
 end
 
 function constraint_hash(constraint::SingleVariableConstraint)
-    return hash([string(typeof(constraint.set)), constraint.indices])
+    return hash([string(typeof(constraint.std.set)), constraint.std.indices])
 end

--- a/src/lp_model.jl
+++ b/src/lp_model.jl
@@ -12,8 +12,8 @@ function create_lp_model!(model)
     lp_backend = backend(lp_model)
     # iterate through all constraints and add all supported constraints
     for constraint in com.constraints
-        if MOI.supports_constraint(model.options.lp_optimizer.optimizer_constructor(), typeof(constraint.fct), typeof(constraint.set))
-            MOI.add_constraint(lp_backend, constraint.fct, constraint.set)
+        if MOI.supports_constraint(model.options.lp_optimizer.optimizer_constructor(), typeof(constraint.std.fct), typeof(constraint.std.set))
+            MOI.add_constraint(lp_backend, constraint.std.fct, constraint.std.set)
         end
     end
     # add objective

--- a/src/objective.jl
+++ b/src/objective.jl
@@ -112,9 +112,9 @@ function get_best_bound(
     # update bounds by constraints
     # check each constraint which has `enforce_bound = true` for a better bound
     for constraint in com.constraints
-        if constraint.enforce_bound
-            update_best_bound_constraint!(com, constraint, constraint.fct, constraint.set, var_idx, lb, ub)
-            for bound in constraint.bound_rhs
+        if constraint.std.enforce_bound
+            update_best_bound_constraint!(com, constraint, constraint.std.fct, constraint.std.set, var_idx, lb, ub)
+            for bound in constraint.std.bound_rhs
                 set_lower_bound(com.lp_x[bound.idx], bound.lb)
                 set_upper_bound(com.lp_x[bound.idx], bound.ub)
             end

--- a/src/type_inits.jl
+++ b/src/type_inits.jl
@@ -18,6 +18,12 @@ Variable(idx) = Variable(
 
 MatchingInit() = MatchingInit(0, Int[], Int[], Int[], Int[], Int[], Int[], Bool[], Bool[])
 
+function ConstraintInternals(idx::Int, fct, set, indices::Vector{Int})
+    return ConstraintInternals(
+        idx, fct, set, indices, Int[], false, nothing, zero(UInt64)
+    )
+end
+
 function LinearConstraint(
     fct::MOI.ScalarAffineFunction,
     set::MOI.AbstractScalarSet,
@@ -44,21 +50,15 @@ function LinearConstraint(
     pre_mins = zeros(promote_T, length(indices))
     # this can be changed later in `set_in_all_different!` but needs to be initialized with false
     in_all_different = false
-    pvals = Int[]
 
+    internals = ConstraintInternals(0, fct, set, indices)
     lc = LinearConstraint(
-        0, # idx will be filled later
-        fct,
-        set,
-        indices,
-        pvals,
+        internals,
         in_all_different,
         mins,
         maxs,
         pre_mins,
         pre_maxs,
-        false, # `enforce_bound` can be changed later but should be set to false by default
-        zero(UInt64),
     )
     return lc
 end

--- a/test/small_special.jl
+++ b/test/small_special.jl
@@ -79,10 +79,10 @@
         z = CS.add_var!(com, 0, 9)
 
         c1 = 2x + 3x == 5
-        @test length(c1.indices) == 1
-        @test c1.indices[1] == 1
-        @test c1.fct.terms[1].coefficient == 5
-        @test c1.set.value == 5
+        @test length(c1.std.indices) == 1
+        @test c1.std.indices[1] == 1
+        @test c1.std.fct.terms[1].coefficient == 5
+        @test c1.std.set.value == 5
 
         CS.add_constraint!(com, 2x + 3x == 5)
         CS.add_constraint!(com, 2x - 3y + 6 + x == z)


### PR DESCRIPTION
Adding new constraints should be as easy as possible therefore developers of new constraints shouldn't need to care about adding stuff like `pvals`, `enforce_bound` etc to its own constraint type. Just an `std::ConstraintInternals` is needed.