### PR TITLE
Indicator constraint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # ConstrainSolver.jl - Changelog
 
+## v0.1.8 (15th of June 2020)
+- Support for indicator constraints
+    - i.e. `@constraint(m, b => { x + y <= 10 })`
+
 ## v0.1.7 (22th of May 2020)
 - Better feasibility and pruning in `==`
 - **Bugfixes:**

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ConstraintSolver"
 uuid = "e0e52ebd-5523-408d-9ca3-7641f1cd1405"
 authors = ["Ole Kröger <o.kroeger@opensourc.es>"]
-version = "0.1.7"
+version = "0.1.8"
 
 [deps]
 Formatting = "59287772-0a20-5a39-b81b-1366585eb4c0"

--- a/docs/src/supported.md
+++ b/docs/src/supported.md
@@ -43,12 +43,14 @@ It's a bit more but still not as fully featured as I would like it to be.
   - [X] `==`
   - [X] `<=`
   - [X] `>=`
+  - [X] `!=`
 - [X] All different
   - `@constraint(m, [x,y,z] in CS.AllDifferentSet())`
-- [X] Support for `!=`
-  - [X] Supports `a != b` with `a` and `b` being single variables
-  - [X] Support for linear unequal constraints [#66](https://github.com/Wikunia/ConstraintSolver.jl/issues/66)
 - [X] `TableSet` constraint [#130](https://github.com/Wikunia/ConstraintSolver.jl/pull/130)
+- [X] Indicator constraints [#167](https://github.com/Wikunia/ConstraintSolver.jl/pull/167)
+  - i.e `@constraint(m, b => {x + y >= 12})`
+  - [X] for affine inner constraints
+  - [ ] for all types of inner constraints
 - [ ] Scheduling constraints
 - [ ] Cycle constraints
 

--- a/docs/src/supported.md
+++ b/docs/src/supported.md
@@ -50,7 +50,7 @@ It's a bit more but still not as fully featured as I would like it to be.
 - [X] Indicator constraints [#167](https://github.com/Wikunia/ConstraintSolver.jl/pull/167)
   - i.e `@constraint(m, b => {x + y >= 12})`
   - [X] for affine inner constraints
-  - [ ] for all types of inner constraints
+  - [X] for all types of inner constraints
 - [ ] Scheduling constraints
 - [ ] Cycle constraints
 

--- a/src/ConstraintSolver.jl
+++ b/src/ConstraintSolver.jl
@@ -52,8 +52,8 @@ include("constraints/less_than.jl")
 include("constraints/svc.jl")
 include("constraints/equal.jl")
 include("constraints/not_equal.jl")
-
 include("constraints/table.jl")
+include("constraints/indicator.jl")
 
 """
     add_var!(com::CS.CoM, from::Int, to::Int; fix=nothing)

--- a/src/MOI_wrapper/MOI_wrapper.jl
+++ b/src/MOI_wrapper/MOI_wrapper.jl
@@ -1,5 +1,6 @@
 const SVF = MOI.SingleVariable
 const SAF = MOI.ScalarAffineFunction
+const VAF = MOI.VectorAffineFunction
 
 # indices
 const VI = MOI.VariableIndex

--- a/src/constraints/indicator.jl
+++ b/src/constraints/indicator.jl
@@ -1,0 +1,90 @@
+"""
+    prune_constraint!(
+        com::CS.CoM,
+        constraint::IndicatorConstraint,
+        fct::VAF{T},
+        set::IS;
+        logs = true,
+    ) where {A, T<:Real, ASS<:MOI.AbstractScalarSet, IS<:MOI.IndicatorSet{A, ASS}}
+
+Prune the search space given the indicator constraint. An indicator constraint is of the form `b => {x + y == 2}`.
+Where the constraint in `{ }` is currently a linear constraint.
+
+Return whether the search space is still feasible.
+"""
+function prune_constraint!(
+    com::CS.CoM,
+    constraint::IndicatorConstraint,
+    fct::VAF{T},
+    set::IS;
+    logs = true,
+) where {A, T<:Real, ASS<:MOI.AbstractScalarSet, IS<:MOI.IndicatorSet{A, ASS}}
+    indicator_var_idx = constraint.std.indices[1]
+    search_space = com.search_space
+    indicator_var = search_space[indicator_var_idx]
+    # still feasible but nothing to prune
+    !isfixed(indicator_var) && return true
+    # if active
+    CS.value(indicator_var) != Int(constraint.activate_on) && return true
+    inner_constraint = constraint.inner_constraint
+    return prune_constraint!(com, inner_constraint, inner_constraint.std.fct, inner_constraint.std.set; logs=logs)
+end
+
+"""
+    still_feasible(
+        com::CoM,
+        constraint::IndicatorConstraint,
+        fct::VAF{T},
+        set::IS,
+        val::Int,
+        index::Int,
+    ) where {A, T<:Real, ASS<:MOI.AbstractScalarSet, IS<:MOI.IndicatorSet{A, ASS}}
+
+Return whether the search space is still feasible when setting `search_space[index]` to value.
+"""
+function still_feasible(
+    com::CoM,
+    constraint::IndicatorConstraint,
+    fct::VAF{T},
+    set::IS,
+    val::Int,
+    index::Int,
+) where {A, T<:Real, ASS<:MOI.AbstractScalarSet, IS<:MOI.IndicatorSet{A, ASS}}
+    indicator_var_idx = constraint.std.indices[1]
+    search_space = com.search_space
+    indicator_var = search_space[indicator_var_idx]
+    # still feasible but nothing to prune
+    !isfixed(indicator_var) && index != indicator_var_idx && return true
+    # if deactivating or is deactivated
+    if index != indicator_var_idx
+        CS.value(indicator_var) != Int(constraint.activate_on) && return true
+    else
+        val != Int(constraint.activate_on) && return true
+    end
+    # if activating or activated check the inner constraint
+    inner_constraint = constraint.inner_constraint
+    return still_feasible(com, inner_constraint, inner_constraint.std.fct, inner_constraint.std.set, val, index)
+end
+
+"""
+    is_solved_constraint(
+        constraint::IndicatorConstraint,
+        fct::VAF{T},
+        set::IS,
+        values::Vector{Int}
+    ) where {A, T<:Real, ASS<:MOI.AbstractScalarSet, IS<:MOI.IndicatorSet{A, ASS}}
+
+Return whether given `values` the constraint is fulfilled.
+"""
+function is_solved_constraint(
+    constraint::IndicatorConstraint,
+    fct::VAF{T},
+    set::IS,
+    values::Vector{Int}
+) where {A, T<:Real, ASS<:MOI.AbstractScalarSet, IS<:MOI.IndicatorSet{A, ASS}}
+    if values[1] == Int(constraint.activate_on)
+        inner_constraint = constraint.inner_constraint
+        return is_solved_constraint(inner_constraint, inner_constraint.std.fct, inner_constraint.std.indices, values[2:end])
+    end
+    return true
+end

--- a/src/constraints/indicator.jl
+++ b/src/constraints/indicator.jl
@@ -2,10 +2,10 @@
     prune_constraint!(
         com::CS.CoM,
         constraint::IndicatorConstraint,
-        fct::VAF{T},
+        fct::Union{MOI.VectorOfVariables, VAF{T}},
         set::IS;
         logs = true,
-    ) where {A, T<:Real, ASS<:MOI.AbstractScalarSet, IS<:MOI.IndicatorSet{A, ASS}}
+    ) where {A, T<:Real, ASS<:MOI.AbstractScalarSet, IS<:Union{IndicatorSet{A}, MOI.IndicatorSet{A, ASS}}}
 
 Prune the search space given the indicator constraint. An indicator constraint is of the form `b => {x + y == 2}`.
 Where the constraint in `{ }` is currently a linear constraint.
@@ -15,10 +15,10 @@ Return whether the search space is still feasible.
 function prune_constraint!(
     com::CS.CoM,
     constraint::IndicatorConstraint,
-    fct::VAF{T},
+    fct::Union{MOI.VectorOfVariables, VAF{T}},
     set::IS;
     logs = true,
-) where {A, T<:Real, ASS<:MOI.AbstractScalarSet, IS<:MOI.IndicatorSet{A, ASS}}
+) where {A, T<:Real, ASS<:MOI.AbstractScalarSet, IS<:Union{IndicatorSet{A}, MOI.IndicatorSet{A, ASS}}}
     indicator_var_idx = constraint.std.indices[1]
     search_space = com.search_space
     indicator_var = search_space[indicator_var_idx]
@@ -34,22 +34,22 @@ end
     still_feasible(
         com::CoM,
         constraint::IndicatorConstraint,
-        fct::VAF{T},
+        fct::Union{MOI.VectorOfVariables, VAF{T}},
         set::IS,
         val::Int,
         index::Int,
-    ) where {A, T<:Real, ASS<:MOI.AbstractScalarSet, IS<:MOI.IndicatorSet{A, ASS}}
+    ) where {A, T<:Real, ASS<:MOI.AbstractScalarSet, IS<:Union{IndicatorSet{A}, MOI.IndicatorSet{A, ASS}}}
 
 Return whether the search space is still feasible when setting `search_space[index]` to value.
 """
 function still_feasible(
     com::CoM,
     constraint::IndicatorConstraint,
-    fct::VAF{T},
+    fct::Union{MOI.VectorOfVariables, VAF{T}},
     set::IS,
     val::Int,
     index::Int,
-) where {A, T<:Real, ASS<:MOI.AbstractScalarSet, IS<:MOI.IndicatorSet{A, ASS}}
+) where {A, T<:Real, ASS<:MOI.AbstractScalarSet, IS<:Union{IndicatorSet{A}, MOI.IndicatorSet{A, ASS}}}
     indicator_var_idx = constraint.std.indices[1]
     search_space = com.search_space
     indicator_var = search_space[indicator_var_idx]
@@ -69,19 +69,19 @@ end
 """
     is_solved_constraint(
         constraint::IndicatorConstraint,
-        fct::VAF{T},
+        fct::Union{MOI.VectorOfVariables, VAF{T}},
         set::IS,
         values::Vector{Int}
-    ) where {A, T<:Real, ASS<:MOI.AbstractScalarSet, IS<:MOI.IndicatorSet{A, ASS}}
+    ) where {A, T<:Real, ASS<:MOI.AbstractScalarSet, IS<:Union{IndicatorSet{A}, MOI.IndicatorSet{A, ASS}}}
 
 Return whether given `values` the constraint is fulfilled.
 """
 function is_solved_constraint(
     constraint::IndicatorConstraint,
-    fct::VAF{T},
+    fct::Union{MOI.VectorOfVariables, VAF{T}},
     set::IS,
     values::Vector{Int}
-) where {A, T<:Real, ASS<:MOI.AbstractScalarSet, IS<:MOI.IndicatorSet{A, ASS}}
+) where {A, T<:Real, ASS<:MOI.AbstractScalarSet, IS<:Union{IndicatorSet{A}, MOI.IndicatorSet{A, ASS}}}
     if values[1] == Int(constraint.activate_on)
         inner_constraint = constraint.inner_constraint
         return is_solved_constraint(inner_constraint, inner_constraint.std.fct, inner_constraint.std.set, values[2:end])

--- a/src/constraints/indicator.jl
+++ b/src/constraints/indicator.jl
@@ -84,7 +84,7 @@ function is_solved_constraint(
 ) where {A, T<:Real, ASS<:MOI.AbstractScalarSet, IS<:MOI.IndicatorSet{A, ASS}}
     if values[1] == Int(constraint.activate_on)
         inner_constraint = constraint.inner_constraint
-        return is_solved_constraint(inner_constraint, inner_constraint.std.fct, inner_constraint.std.indices, values[2:end])
+        return is_solved_constraint(inner_constraint, inner_constraint.std.fct, inner_constraint.std.set, values[2:end])
     end
     return true
 end

--- a/src/hashes.jl
+++ b/src/hashes.jl
@@ -20,3 +20,7 @@ end
 function constraint_hash(constraint::SingleVariableConstraint)
     return hash([string(typeof(constraint.std.set)), constraint.std.indices])
 end
+
+function constraint_hash(constraint::IndicatorConstraint)
+    return hash([string(typeof(constraint.std.set)), constraint.std.indices, constraint.activate_on, constraint_hash(constraint.inner_constraint)])
+end

--- a/src/types.jl
+++ b/src/types.jl
@@ -82,6 +82,8 @@ end
 ====================== TYPES FOR CONSTRAINTS ========================================
 ====================================================================================#
 
+abstract type Constraint end
+
 """
     BoundRhsVariable 
 idx - variable index in the lp Model
@@ -145,6 +147,13 @@ mutable struct TableBacktrackInfo
     indices  :: Vector{Int}
 end
 
+struct IndicatorSet{A} <: MOI.AbstractVectorSet
+    ind_var :: JuMP.VariableRef
+    func    :: MOI.VectorOfVariables
+    set     :: MOI.AbstractVectorSet
+    dimension::Int
+end
+
 #====================================================================================
 ====================================================================================#
 
@@ -171,8 +180,6 @@ end
 #====================================================================================
 ====================== CONSTRAINTS ==================================================
 ====================================================================================#
-
-abstract type Constraint end
 
 mutable struct BasicConstraint <: Constraint
     std::ConstraintInternals

--- a/src/types.jl
+++ b/src/types.jl
@@ -29,6 +29,7 @@ mutable struct NumberConstraintTypes
     notequal::Int
     alldifferent::Int
     table::Int
+    indicator::Int
 end
 
 mutable struct CSInfo
@@ -224,6 +225,12 @@ mutable struct TableConstraint <: Constraint
     unfixed_vars::Vector{Int}
     sum_min::Vector{Int}
     sum_max::Vector{Int}
+end
+
+mutable struct IndicatorConstraint <: Constraint
+    std::ConstraintInternals
+    activate_on::MOI.ActivationCondition
+    inner_constraint::Constraint
 end
 
 #====================================================================================

--- a/test/constraints/indicator.jl
+++ b/test/constraints/indicator.jl
@@ -1,5 +1,5 @@
 @testset "IndicatorConstraint" begin
-@testset "Basic I" begin
+@testset "Basic ==" begin
     m = Model(CSJuMPTestOptimizer())
     @variable(m, x, CS.Integers([1,2,4]))
     @variable(m, y, CS.Integers([3,4]))
@@ -14,7 +14,7 @@
     @test JuMP.value(y) ≈ 3
 end
 
-@testset "Basic II" begin
+@testset "Basic !=" begin
     m = Model(CSJuMPTestOptimizer())
     @variable(m, x, CS.Integers([1,2,4]))
     @variable(m, y, CS.Integers([3,4]))
@@ -27,5 +27,63 @@ end
     @test JuMP.value(b) ≈ 0.0
     @test JuMP.value(x) ≈ 4
     @test JuMP.value(y) ≈ 4
+end
+
+@testset "Basic >=" begin
+    m = Model(CSJuMPTestOptimizer())
+    @variable(m, x, CS.Integers([1,2,4]))
+    @variable(m, y, CS.Integers([3,4]))
+    @variable(m, b, Bin)
+    @constraint(m, b => {x + y >= 6})
+    @objective(m, Min, x+y)
+    optimize!(m)
+    @test JuMP.termination_status(m) == MOI.OPTIMAL
+    @test JuMP.objective_value(m) ≈ 4.0
+    @test JuMP.value(b) ≈ 0.0
+    @test JuMP.value(x) ≈ 1
+    @test JuMP.value(y) ≈ 3
+
+    m = Model(CSJuMPTestOptimizer())
+    @variable(m, x, CS.Integers([1,2,4]))
+    @variable(m, y, CS.Integers([3,4]))
+    @variable(m, b, Bin)
+    @constraint(m, b == 1)
+    @constraint(m, b => {x + y >= 6})
+    @objective(m, Min, x+y)
+    optimize!(m)
+    @test JuMP.termination_status(m) == MOI.OPTIMAL
+    @test JuMP.objective_value(m) ≈ 6.0
+    @test JuMP.value(b) ≈ 1.0
+    @test JuMP.value(x) ≈ 2
+    @test JuMP.value(y) ≈ 4
+end
+
+@testset "Basic <=" begin
+    m = Model(CSJuMPTestOptimizer())
+    @variable(m, x, CS.Integers([1,2,4]))
+    @variable(m, y, CS.Integers([3,4]))
+    @variable(m, b, Bin)
+    @constraint(m, b => {x + y <= 4})
+    @objective(m, Max, x+y)
+    optimize!(m)
+    @test JuMP.termination_status(m) == MOI.OPTIMAL
+    @test JuMP.objective_value(m) ≈ 8.0
+    @test JuMP.value(b) ≈ 0.0
+    @test JuMP.value(x) ≈ 4
+    @test JuMP.value(y) ≈ 4
+
+    m = Model(CSJuMPTestOptimizer())
+    @variable(m, x, CS.Integers([1,2,4]))
+    @variable(m, y, CS.Integers([3,4]))
+    @variable(m, b, Bin)
+    @constraint(m, b == 1)
+    @constraint(m, b => {x + y <= 4})
+    @objective(m, Max, x+y)
+    optimize!(m)
+    @test JuMP.termination_status(m) == MOI.OPTIMAL
+    @test JuMP.objective_value(m) ≈ 4.0
+    @test JuMP.value(b) ≈ 1.0
+    @test JuMP.value(x) ≈ 1
+    @test JuMP.value(y) ≈ 3
 end
 end

--- a/test/constraints/indicator.jl
+++ b/test/constraints/indicator.jl
@@ -16,6 +16,21 @@
     @test is_solved(com)
 end
 
+@testset "Basic == Active on zero" begin
+    m = Model(CSJuMPTestOptimizer())
+    @variable(m, x, CS.Integers([1,2,4]))
+    @variable(m, y, CS.Integers([3,4]))
+    @variable(m, b, Bin)
+    @constraint(m, !b => {x + y == 9})
+    @objective(m, Min, b)
+    optimize!(m)
+    @test JuMP.termination_status(m) == MOI.OPTIMAL
+    @test JuMP.objective_value(m) ≈ 1.0
+    @test JuMP.value(b) ≈ 1.0
+    com = JuMP.backend(m).optimizer.model.inner
+    @test is_solved(com)
+end
+
 @testset "Basic == infeasible" begin
     m = Model(CSJuMPTestOptimizer())
     @variable(m, x, CS.Integers([1,4]))

--- a/test/constraints/indicator.jl
+++ b/test/constraints/indicator.jl
@@ -158,4 +158,23 @@ end
     com = JuMP.backend(m).optimizer.model.inner
     @test is_solved(com)
 end
+
+@testset "Basic AllDifferent negated" begin
+    m = Model(CSJuMPTestOptimizer())
+    @variable(m, 0 <= x <= 1, Int)
+    @variable(m, 0 <= y <= 1, Int)
+    @variable(m, a, Bin)
+    @constraint(m, x +y <= 1)
+    @constraint(m, [a, x] in CS.AllDifferentSet())
+    @constraint(m, !a => {[x,y] in CS.AllDifferentSet()})
+    @objective(m, Min, a)
+    optimize!(m)
+    @test JuMP.termination_status(m) == MOI.OPTIMAL
+    @test JuMP.objective_value(m) ≈ 0.0
+    @test JuMP.value(a) ≈ 0.0
+    @test JuMP.value(y) ≈ 0.0
+    @test JuMP.value(x) ≈ 1.0
+    com = JuMP.backend(m).optimizer.model.inner
+    @test is_solved(com)
+end
 end

--- a/test/constraints/indicator.jl
+++ b/test/constraints/indicator.jl
@@ -1,0 +1,31 @@
+@testset "IndicatorConstraint" begin
+@testset "Basic I" begin
+    m = Model(CSJuMPTestOptimizer())
+    @variable(m, x, CS.Integers([1,2,4]))
+    @variable(m, y, CS.Integers([3,4]))
+    @variable(m, b, Bin)
+    @constraint(m, b => {x + y == 7})
+    @objective(m, Max, b)
+    optimize!(m)
+    @test JuMP.termination_status(m) == MOI.OPTIMAL
+    @test JuMP.objective_value(m) ≈ 1.0
+    @test JuMP.value(b) ≈ 1.0
+    @test JuMP.value(x) ≈ 4
+    @test JuMP.value(y) ≈ 3
+end
+
+@testset "Basic II" begin
+    m = Model(CSJuMPTestOptimizer())
+    @variable(m, x, CS.Integers([1,2,4]))
+    @variable(m, y, CS.Integers([3,4]))
+    @variable(m, b, Bin)
+    @constraint(m, b => {x + y != 8})
+    @objective(m, Max, x+y)
+    optimize!(m)
+    @test JuMP.termination_status(m) == MOI.OPTIMAL
+    @test JuMP.objective_value(m) ≈ 8.0
+    @test JuMP.value(b) ≈ 0.0
+    @test JuMP.value(x) ≈ 4
+    @test JuMP.value(y) ≈ 4
+end
+end

--- a/test/constraints/indicator.jl
+++ b/test/constraints/indicator.jl
@@ -122,4 +122,40 @@ end
     com = JuMP.backend(m).optimizer.model.inner
     @test is_solved(com)
 end
+
+@testset "Basic AllDifferent" begin
+    m = Model(CSJuMPTestOptimizer())
+    @variable(m, 0 <= x <= 1, Int)
+    @variable(m, 0 <= y <= 1, Int)
+    @variable(m, a, Bin)
+    @constraint(m, x +y <= 1)
+    @constraint(m, [a, x] in CS.AllDifferentSet())
+    @constraint(m, a => {[a,x,y] in CS.AllDifferentSet()})
+    @objective(m, Max, a)
+    optimize!(m)
+    @test JuMP.termination_status(m) == MOI.OPTIMAL
+    @test JuMP.objective_value(m) ≈ 0.0
+    @test JuMP.value(a) ≈ 0.0
+    com = JuMP.backend(m).optimizer.model.inner
+    @test is_solved(com)
+end
+
+@testset "Basic AllDifferent achievable" begin
+    m = Model(CSJuMPTestOptimizer())
+    @variable(m, 0 <= x <= 1, Int)
+    @variable(m, 0 <= y <= 1, Int)
+    @variable(m, a, Bin)
+    @constraint(m, x +y <= 1)
+    @constraint(m, [a, x] in CS.AllDifferentSet())
+    @constraint(m, a => {[x,y] in CS.AllDifferentSet()})
+    @objective(m, Max, a)
+    optimize!(m)
+    @test JuMP.termination_status(m) == MOI.OPTIMAL
+    @test JuMP.objective_value(m) ≈ 1.0
+    @test JuMP.value(a) ≈ 1.0
+    @test JuMP.value(y) ≈ 1.0
+    @test JuMP.value(x) ≈ 0.0
+    com = JuMP.backend(m).optimizer.model.inner
+    @test is_solved(com)
+end
 end

--- a/test/constraints/indicator.jl
+++ b/test/constraints/indicator.jl
@@ -12,6 +12,21 @@
     @test JuMP.value(b) ≈ 1.0
     @test JuMP.value(x) ≈ 4
     @test JuMP.value(y) ≈ 3
+    com = JuMP.backend(m).optimizer.model.inner
+    @test is_solved(com)
+end
+
+@testset "Basic == infeasible" begin
+    m = Model(CSJuMPTestOptimizer())
+    @variable(m, x, CS.Integers([1,4]))
+    @variable(m, y, CS.Integers([3,4]))
+    @variable(m, b, Bin)
+    @constraint(m, b == 1)
+    @constraint(m, b => {x + y == 6})
+    optimize!(m)
+    @test JuMP.termination_status(m) == MOI.INFEASIBLE
+    com = JuMP.backend(m).optimizer.model.inner
+    @test !is_solved(com)
 end
 
 @testset "Basic !=" begin
@@ -27,6 +42,8 @@ end
     @test JuMP.value(b) ≈ 0.0
     @test JuMP.value(x) ≈ 4
     @test JuMP.value(y) ≈ 4
+    com = JuMP.backend(m).optimizer.model.inner
+    @test is_solved(com)
 end
 
 @testset "Basic >=" begin
@@ -56,6 +73,8 @@ end
     @test JuMP.value(b) ≈ 1.0
     @test JuMP.value(x) ≈ 2
     @test JuMP.value(y) ≈ 4
+    com = JuMP.backend(m).optimizer.model.inner
+    @test is_solved(com)
 end
 
 @testset "Basic <=" begin
@@ -85,5 +104,7 @@ end
     @test JuMP.value(b) ≈ 1.0
     @test JuMP.value(x) ≈ 1
     @test JuMP.value(y) ≈ 3
+    com = JuMP.backend(m).optimizer.model.inner
+    @test is_solved(com)
 end
 end

--- a/test/moi.jl
+++ b/test/moi.jl
@@ -58,6 +58,11 @@
             typeof(f),
             typeof(indicator_set)
         )
+        @test MOI.supports_constraint(
+            optimizer,
+            MOI.VectorOfVariables,
+            CS.IndicatorSet{MOI.ACTIVATE_ON_ONE}
+        )
 
 
         # TimeLimit

--- a/test/moi.jl
+++ b/test/moi.jl
@@ -33,6 +33,33 @@
             CS.NotEqualTo{Float64},
         )
 
+        f = MOI.VectorAffineFunction(
+            [MOI.VectorAffineTerm(1, MOI.ScalarAffineTerm(1.0, MOI.VariableIndex(1))),
+            MOI.VectorAffineTerm(2, MOI.ScalarAffineTerm(1.0, MOI.VariableIndex(2))),
+            MOI.VectorAffineTerm(2, MOI.ScalarAffineTerm(1.0, MOI.VariableIndex(3))),
+            ],
+            [0.0, 0.0],
+        )
+        indicator_set = MOI.IndicatorSet{MOI.ACTIVATE_ON_ONE}(MOI.LessThan(9.0))
+        @test MOI.supports_constraint(
+            optimizer,
+            typeof(f),
+            typeof(indicator_set)
+        )
+        indicator_set = MOI.IndicatorSet{MOI.ACTIVATE_ON_ONE}(MOI.GreaterThan(9.0))
+        @test MOI.supports_constraint(
+            optimizer,
+            typeof(f),
+            typeof(indicator_set)
+        )
+        indicator_set = MOI.IndicatorSet{MOI.ACTIVATE_ON_ONE}(MOI.EqualTo(9.0))
+        @test MOI.supports_constraint(
+            optimizer,
+            typeof(f),
+            typeof(indicator_set)
+        )
+
+
         # TimeLimit
         @test MOI.supports(optimizer, MOI.TimeLimitSec())
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -22,6 +22,7 @@ include("unit/index.jl")
 include("options.jl")
 include("moi.jl")
 include("constraints/table.jl")
+include("constraints/indicator.jl")
 
 include("lp_solver.jl")
 

--- a/test/unit/constraints/indicator.jl
+++ b/test/unit/constraints/indicator.jl
@@ -1,0 +1,44 @@
+@testset "indicator" begin
+    m = Model(optimizer_with_attributes(CS.Optimizer, "no_prune" => true, "logging" => []))
+    @variable(m, x, CS.Integers([-3,1,2,3]))
+    @variable(m, y, CS.Integers([-3,1,2,3]))
+    @variable(m, b, Bin)
+    @constraint(m, b => {x+y+1 == 5})
+    optimize!(m)
+    com = JuMP.backend(m).optimizer.model.inner
+    constraint = get_constraints_by_type(com, CS.IndicatorConstraint)[1]
+
+    @test CS.is_solved_constraint(constraint, constraint.std.fct, constraint.std.set, [1,2,2])
+    @test !CS.is_solved_constraint(constraint, constraint.std.fct, constraint.std.set, [1,2,3])
+    @test CS.is_solved_constraint(constraint, constraint.std.fct, constraint.std.set, [0,2,3])
+
+    constr_indices = constraint.std.indices
+    @test CS.still_feasible(com, constraint, constraint.std.fct, constraint.std.set, -3, constr_indices[2])
+    @test CS.still_feasible(com, constraint, constraint.std.fct, constraint.std.set, 1, constr_indices[3])
+    # not actually feasible but will not be tested fully here
+    CS.fix!(com, com.search_space[constr_indices[1]], 1)
+    # will be tested when setting the next
+    @test !CS.still_feasible(com, constraint, constraint.std.fct, constraint.std.set, -3, constr_indices[3])
+
+    # need to create a backtrack_vec to reverse pruning
+    dummy_backtrack_obj = CS.BacktrackObj(com)
+    push!(com.backtrack_vec, dummy_backtrack_obj)
+    # reverse previous fix
+    CS.reverse_pruning!(com, 1)
+    com.c_backtrack_idx = 1
+    # now setting it to 1 should be feasible
+    @test CS.still_feasible(com, constraint, constraint.std.fct, constraint.std.set, -3, constr_indices[3])
+
+    @test CS.prune_constraint!(com, constraint, constraint.std.fct, constraint.std.set)
+    for ind in constr_indices[2:3]
+        @test sort(CS.values(com.search_space[ind])) == [-3,1,2,3]
+    end
+    @test sort(CS.values(com.search_space[1])) == [0,1]
+    # feasible but remove -3
+    @test CS.fix!(com, com.search_space[constr_indices[1]], 1)
+    @test CS.prune_constraint!(com, constraint, constraint.std.fct, constraint.std.set)
+    for ind in constr_indices[2:3]
+        @test sort(CS.values(com.search_space[ind])) == [1,2,3]
+    end
+    CS.values(com.search_space[constr_indices[1]]) == [1]
+end

--- a/test/unit/index.jl
+++ b/test/unit/index.jl
@@ -16,4 +16,5 @@ end
     include("constraints/not_equal.jl")
     include("constraints/svc.jl")
     include("constraints/table.jl")
+    include("constraints/indicator.jl")
 end


### PR DESCRIPTION
Fix #166 
Currently it only supports inner constraints of the form `>=, <=, ==` and `!=` not complicated constraints like `alldifferent` or `table` this is due to limitations in JuMP/MOI.

ToDo:
- [x] More tests
- [x] Add to docs
- [ ] Probably add a benchmark set