### PR TITLE
test v1.5 instead of v1.4

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        julia-version: [1.0.4, 1.4.0]
+        julia-version: [1.0.4, 1.5.0]
         julia-arch: [x64]
         os: [ubuntu-latest, windows-latest, macOS-latest]
     


### PR DESCRIPTION
New version of Julia is out! So let's run the test on v1.5 and LTS instead of v1.4 and LTS.