### PR TITLE
Removed weird num_backtrack_obj

### DIFF
--- a/src/ConstraintSolver.jl
+++ b/src/ConstraintSolver.jl
@@ -241,6 +241,7 @@ function addBacktrackObj2Backtrack_vec!(
     com::CS.CoM,
 )
     push!(backtrack_vec, backtrack_obj)
+    @assert length(backtrack_vec) == backtrack_obj.idx
     for v in com.search_space
         push!(v.changes, Vector{Tuple{Symbol,Int,Int,Int}}())
     end

--- a/src/type_inits.jl
+++ b/src/type_inits.jl
@@ -122,6 +122,22 @@ function NumberConstraintTypes()
     return NumberConstraintTypes(zeros(Int, length(fieldnames(NumberConstraintTypes)))...)
 end
 
+function new_BacktrackObj(com::CS.CoM, parent_idx, depth, vidx, lb, ub)
+    parent = com.backtrack_vec[parent_idx]
+    return BacktrackObj{parametric_type(com)}(
+        length(com.backtrack_vec)+1, # idx
+        parent_idx,
+        depth,
+        :Open, # status
+        vidx,
+        lb, # lb and ub only take effect if vidx != 0
+        ub, # ub
+        parent.best_bound,
+        parent.solution,
+        zeros(length(com.search_space)) # solution values of bound computation
+    )
+end
+
 function BacktrackObj(com::CS.CoM)
     return BacktrackObj(
         1, # idx

--- a/src/types.jl
+++ b/src/types.jl
@@ -302,7 +302,7 @@ mutable struct BacktrackObj{T<:Real}
     ub::Int
     best_bound::T
     primal_start::Vector{Float64}
-    solution::Vector{Float64} # holds the solution values
+    solution::Vector{Float64} # holds the solution values of the bound computation
 end
 
 


### PR DESCRIPTION
Every BacktrackObj that gets created and added will be at the position of its `backtrack_id`.
For checking how many backtrack objects exist we can simply use the `length` function. 

I don't know why I did something else before :smiley: 