### PR TITLE
Feature priority queue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 - Using faster version of strongly connected components with lower memory footprint
+- Using a priority queue for faster `get_next_node`
+- Removed `further_pruning`
 
 ## v0.4.0 (29th of November 2020)
 **Improvements for graph coloring**

--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,7 @@ authors = ["Ole Kröger <o.kroeger@opensourc.es>"]
 version = "0.4.0"
 
 [deps]
+DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
 Formatting = "59287772-0a20-5a39-b81b-1366585eb4c0"
 JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
 JuMP = "4076af6c-e467-56ae-b986-b466b2749572"

--- a/Project.toml
+++ b/Project.toml
@@ -14,7 +14,7 @@ MatrixNetworks = "4f449596-a032-5618-b826-5a251cb6dc11"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [compat]
-DataStructures = "0.11-0.18"
+DataStructures = "0.11 - 0.18"
 Formatting = "^0.4.1"
 JSON = "~0.18, ~0.19, ~0.20, ~0.21"
 JuMP = "^0.21.3"

--- a/Project.toml
+++ b/Project.toml
@@ -14,6 +14,7 @@ MatrixNetworks = "4f449596-a032-5618-b826-5a251cb6dc11"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [compat]
+DataStructures = "0.11-0.18"
 Formatting = "^0.4.1"
 JSON = "~0.18, ~0.19, ~0.20, ~0.21"
 JuMP = "^0.21.3"

--- a/Project.toml
+++ b/Project.toml
@@ -14,7 +14,7 @@ MatrixNetworks = "4f449596-a032-5618-b826-5a251cb6dc11"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [compat]
-DataStructures = "0.11 - 0.18"
+DataStructures = "~0.11, ~0.12, ~0.13, ~0.14, ~0.15, ~0.16, ~0.17, ~0.18"
 Formatting = "^0.4.1"
 JSON = "~0.18, ~0.19, ~0.20, ~0.21"
 JuMP = "^0.21.3"

--- a/docs/Manifest.toml
+++ b/docs/Manifest.toml
@@ -70,16 +70,16 @@ uuid = "e66e0078-7015-5450-92f7-15fbd957f2ae"
 version = "0.3.3+0"
 
 [[ConstraintSolver]]
-deps = ["Formatting", "JSON", "JuMP", "LightGraphs", "MathOptInterface", "MatrixNetworks", "Statistics"]
+deps = ["DataStructures", "Formatting", "JSON", "JuMP", "LightGraphs", "MathOptInterface", "MatrixNetworks", "Statistics"]
 path = ".."
 uuid = "e0e52ebd-5523-408d-9ca3-7641f1cd1405"
-version = "0.3.1"
+version = "0.4.0"
 
 [[DataStructures]]
 deps = ["InteractiveUtils", "OrderedCollections"]
-git-tree-sha1 = "be680f1ad03c0a03796aa3fda5a2180df7f83b46"
+git-tree-sha1 = "88d48e133e6d3dd68183309877eac74393daa7eb"
 uuid = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
-version = "0.17.18"
+version = "0.17.20"
 
 [[Dates]]
 deps = ["Printf"]

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,5 +1,6 @@
 [deps]
 ConstraintSolver = "e0e52ebd-5523-408d-9ca3-7641f1cd1405"
+DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 Formatting = "59287772-0a20-5a39-b81b-1366585eb4c0"
 JuMP = "4076af6c-e467-56ae-b986-b466b2749572"

--- a/src/ConstraintSolver.jl
+++ b/src/ConstraintSolver.jl
@@ -1,5 +1,6 @@
 module ConstraintSolver
 
+using DataStructures
 using Formatting
 using JSON
 using JuMP:
@@ -147,10 +148,14 @@ function get_best_bound(com::CS.CoM, backtrack_obj::BacktrackObj; vidx = 0, lb =
     if com.sense == MOI.FEASIBILITY_SENSE
         return zero(com.best_bound)
     end
+    best_bound = zero(com.best_bound)
     if com.options.lp_optimizer !== nothing
-        return get_best_bound_lp(com, backtrack_obj, vidx, lb, ub)
+        best_bound = get_best_bound_lp(com, backtrack_obj, vidx, lb, ub)
+    else 
+        best_bound = get_best_bound(com, backtrack_obj, com.objective, vidx, lb, ub)
     end
-    return get_best_bound(com, backtrack_obj, com.objective, vidx, lb, ub)
+    update_backtrack_pq!(com, backtrack_obj, best_bound)
+    return best_bound
 end
 
 """
@@ -247,6 +252,8 @@ function addBacktrackObj2Backtrack_vec!(
 )
     push!(backtrack_vec, backtrack_obj)
     @assert length(backtrack_vec) == backtrack_obj.idx
+    add2priorityqueue(com, backtrack_obj)
+
     for v in com.search_space
         push!(v.changes, Vector{Tuple{Symbol,Int,Int,Int}}())
     end
@@ -366,6 +373,12 @@ function add_new_solution!(
             push!(com.solutions, new_sol_obj)
         end
     end
+    # change the traverse strategy for example if it was :DBFS and we found the first solution
+    old_traverse_strategy = com.traverse_strategy
+    com.traverse_strategy = get_traverse_strategy(com; options = com.options)
+    if com.traverse_strategy != old_traverse_strategy
+        changed_traverse_strategy!(com, old_traverse_strategy)
+    end
     return false
 end
 
@@ -452,7 +465,7 @@ function backtrack!(com::CS.CoM, max_bt_steps; sorting = true)
         l = 1
         if !started
             # close the previous backtrack object
-            backtrack_vec[last_backtrack_id].status = :Closed
+            close_node!(com, last_backtrack_id)
             com.input[:logs] && log_node_state!(com.logs[last_backtrack_id], backtrack_vec[last_backtrack_id],  com.search_space)
         end
         # run at least once so that everything is well defined
@@ -496,6 +509,9 @@ function backtrack!(com::CS.CoM, max_bt_steps; sorting = true)
             !feasible && handle_infeasible!(com; finish_pruning=true) && continue
         end
 
+        if backtrack_obj.idx == 25
+            @show further_pruning
+        end  
         if further_pruning
             # prune completely start with all that changed by the fix or by updating best bound
             feasible = prune!(com)
@@ -513,7 +529,7 @@ function backtrack!(com::CS.CoM, max_bt_steps; sorting = true)
             finished = add_new_solution!(com, backtrack_vec, backtrack_obj, log_table)
             if finished
                 # close the previous backtrack object
-                backtrack_vec[last_backtrack_id].status = :Closed
+                close_node!(com, last_backtrack_id)
                 com.input[:logs] && log_node_state!(com.logs[last_backtrack_id], backtrack_vec[last_backtrack_id],  com.search_space)
                 return :Solved
             end
@@ -521,7 +537,7 @@ function backtrack!(com::CS.CoM, max_bt_steps; sorting = true)
         end
 
         if com.info.backtrack_fixes > max_bt_steps
-            backtrack_vec[last_backtrack_id].status = :Closed
+            close_node!(com, last_backtrack_id)
             com.input[:logs] && log_node_state!(com.logs[last_backtrack_id], backtrack_vec[last_backtrack_id],  com.search_space)
             return :NotSolved
         end
@@ -544,7 +560,7 @@ function backtrack!(com::CS.CoM, max_bt_steps; sorting = true)
         )
     end
 
-    backtrack_vec[last_backtrack_id].status = :Closed
+    close_node!(com, last_backtrack_id)
     com.input[:logs] && log_node_state!(com.logs[last_backtrack_id], backtrack_vec[last_backtrack_id],  com.search_space)
     if length(com.solutions) > 0
         set_state_to_best_sol!(com, last_backtrack_id)
@@ -626,7 +642,7 @@ function solve!(com::CS.CoM, options::SolverOptions)
     if options.traverse_strategy == :Auto
         options.traverse_strategy = get_auto_traverse_strategy(com)
     end
-    com.traverse_strategy = get_traverse_strategy(;options = options)
+    com.traverse_strategy = get_traverse_strategy(com; options = options)
     com.branch_split = get_branch_split(;options = options)
 
     set_impl_functions!(com)

--- a/src/ConstraintSolver.jl
+++ b/src/ConstraintSolver.jl
@@ -151,10 +151,10 @@ function get_best_bound(com::CS.CoM, backtrack_obj::BacktrackObj; vidx = 0, lb =
     best_bound = zero(com.best_bound)
     if com.options.lp_optimizer !== nothing
         best_bound = get_best_bound_lp(com, backtrack_obj, vidx, lb, ub)
-    else 
+    else
         best_bound = get_best_bound(com, backtrack_obj, com.objective, vidx, lb, ub)
     end
-    update_backtrack_pq!(com, backtrack_obj, best_bound)
+    set_update_backtrack_pq!(com, backtrack_obj; best_bound = best_bound)
     return best_bound
 end
 

--- a/src/ConstraintSolver.jl
+++ b/src/ConstraintSolver.jl
@@ -502,21 +502,15 @@ function backtrack!(com::CS.CoM, max_bt_steps; sorting = true)
         constraints = com.constraints[com.subscription[vidx]]
         com.info.backtrack_fixes += 1
 
-        further_pruning = true
         # first update the best bound (only constraints which have an index in the objective function)
         if com.sense != MOI.FEASIBILITY_SENSE
             feasible, further_pruning = update_best_bound!(backtrack_obj, com, constraints)
             !feasible && handle_infeasible!(com; finish_pruning=true) && continue
         end
 
-        if backtrack_obj.idx == 25
-            @show further_pruning
-        end  
-        if further_pruning
-            # prune completely start with all that changed by the fix or by updating best bound
-            feasible = prune!(com)
-            !feasible && handle_infeasible!(com; finish_pruning=true) && continue
-        end
+        # prune completely start with all that changed by the fix or by updating best bound
+        feasible = prune!(com)
+        !feasible && handle_infeasible!(com; finish_pruning=true) && continue
         call_finished_pruning!(com)
 
         if log_table

--- a/src/options.jl
+++ b/src/options.jl
@@ -18,7 +18,10 @@ mutable struct SolverOptions
     simplify::Bool
 end
 
-function get_traverse_strategy(;options=SolverOptions())
+function get_traverse_strategy(com; options=SolverOptions())
+    if options.traverse_strategy == :DBFS
+        return isempty(com.solutions) ? Val(:DFS) : Val(:BFS)
+    end
     return Val(options.traverse_strategy)
 end
 

--- a/src/traversing.jl
+++ b/src/traversing.jl
@@ -5,13 +5,13 @@ function changed_traverse_strategy!(com::CS.CoM, old_traverse_strategy)
         for elem in old_backtrack_pq
             idx = elem.first
             priority = elem.second
-            com.backtrack_pq[idx] = PriorityBFS(priority.bound, priority.depth)
+            com.backtrack_pq[idx] = PriorityBFS(priority.bound, priority.depth, priority.neg_idx)
         end
     else # :BFS
         for elem in old_backtrack_pq
             idx = elem.first
             priority = elem.second
-            com.backtrack_pq[idx] = PriorityDFS(priority.depth, priority.bound)
+            com.backtrack_pq[idx] = PriorityDFS(priority.depth, priority.bound, priority.neg_idx)
         end
     end
 end
@@ -24,15 +24,15 @@ Add the backtrack_obj to the priority queue `backtrack_pq`
 function add2priorityqueue(com::CS.CoM, backtrack_obj::BacktrackObj)
      if com.traverse_strategy == Val(:DFS)
         if com.sense == MOI.MIN_SENSE
-            com.backtrack_pq[backtrack_obj.idx] = PriorityDFS(backtrack_obj.depth, -backtrack_obj.best_bound)
+            com.backtrack_pq[backtrack_obj.idx] = PriorityDFS(backtrack_obj.depth, -backtrack_obj.best_bound, -backtrack_obj.idx)
         else
-            com.backtrack_pq[backtrack_obj.idx] = PriorityDFS(backtrack_obj.depth, backtrack_obj.best_bound)
+            com.backtrack_pq[backtrack_obj.idx] = PriorityDFS(backtrack_obj.depth, backtrack_obj.best_bound, -backtrack_obj.idx)
         end
     else
         if com.sense == MOI.MIN_SENSE
-            com.backtrack_pq[backtrack_obj.idx] = PriorityBFS(-backtrack_obj.best_bound, backtrack_obj.depth)
+            com.backtrack_pq[backtrack_obj.idx] = PriorityBFS(-backtrack_obj.best_bound, backtrack_obj.depth, -backtrack_obj.idx)
         else
-            com.backtrack_pq[backtrack_obj.idx] = PriorityBFS(backtrack_obj.best_bound, backtrack_obj.depth)
+            com.backtrack_pq[backtrack_obj.idx] = PriorityBFS(backtrack_obj.best_bound, backtrack_obj.depth, -backtrack_obj.idx)
         end
     end
 end
@@ -60,15 +60,15 @@ Update the priority queue with the new best bound.
 function update_backtrack_pq!(com::CS.CoM, backtrack_obj::BacktrackObj, best_bound)
     if com.traverse_strategy == Val(:DFS)
         if com.sense == MOI.MIN_SENSE
-            com.backtrack_pq[backtrack_obj.idx] = PriorityDFS(backtrack_obj.depth, -best_bound)
+            com.backtrack_pq[backtrack_obj.idx] = PriorityDFS(backtrack_obj.depth, -best_bound, -backtrack_obj.idx)
         else
-            com.backtrack_pq[backtrack_obj.idx] = PriorityDFS(backtrack_obj.depth, best_bound)
+            com.backtrack_pq[backtrack_obj.idx] = PriorityDFS(backtrack_obj.depth, best_bound, -backtrack_obj.idx)
         end
     else
         if com.sense == MOI.MIN_SENSE
-            com.backtrack_pq[backtrack_obj.idx] = PriorityBFS(-best_bound, backtrack_obj.depth, )
+            com.backtrack_pq[backtrack_obj.idx] = PriorityBFS(-best_bound, backtrack_obj.depth, -backtrack_obj.idx)
         else
-            com.backtrack_pq[backtrack_obj.idx] = PriorityBFS(best_bound, backtrack_obj.depth)
+            com.backtrack_pq[backtrack_obj.idx] = PriorityBFS(best_bound, backtrack_obj.depth, -backtrack_obj.idx)
         end
     end
 end

--- a/src/traversing.jl
+++ b/src/traversing.jl
@@ -41,11 +41,12 @@ end
 """
     close_node!(com::CS.CoM, node_idx::Int)
 
-Close a backtrack object node by setting the status to `:Closed` 
+Close a backtrack object node if not already closed by setting the status to `:Closed` 
 and deleting it from the priority queue `backtrack_pq`
 """
 function close_node!(com::CS.CoM, node_idx::Int)
     backtrack_vec = com.backtrack_vec
+    backtrack_vec[node_idx].status == :Closed && return
     backtrack_vec[node_idx].status = :Closed
 
     delete!(com.backtrack_pq, node_idx)

--- a/src/type_inits.jl
+++ b/src/type_inits.jl
@@ -100,10 +100,11 @@ function ConstraintSolverModel(::Type{T} = Float64) where {T<:Real}
         Vector{Int}(), # bt_infeasible
         1, # c_backtrack_idx
         Vector{BacktrackObj{T}}(), # backtrack_vec
+        PriorityQueue{Int, Priority}(Base.Order.Reverse), # priority queue for `get_next_node`
         MOI.FEASIBILITY_SENSE, #
         NoObjective(), #
         Vector{Bool}(), # var_in_obj
-        get_traverse_strategy(),
+        Val(:DFS),
         get_branch_split(),
         zero(T), # best_sol,
         zero(T), # best_bound

--- a/src/types.jl
+++ b/src/types.jl
@@ -101,13 +101,20 @@ abstract type Priority end
 struct PriorityDFS{T<:Real} <: Priority
     depth::Int
     bound::T
+    neg_idx::Int # the negative backtrack index (negative because of maximizing)
 end
 
 function Base.isless(p1::PriorityDFS, p2::PriorityDFS)
     if p1.depth < p2.depth
         return true
     elseif p1.depth == p2.depth
-        return p1.bound < p2.bound
+        if p1.bound < p2.bound
+            return true
+        elseif p1.bound == p2.bound
+            return p1.neg_idx < p2.neg_idx
+        else
+            return false
+        end
     end
     return false
 end
@@ -115,13 +122,20 @@ end
 struct PriorityBFS{T<:Real} <: Priority
     bound::T
     depth::Int
+    neg_idx::Int # the negative backtrack index (negative because of maximizing)
 end
 
 function Base.isless(p1::PriorityBFS, p2::PriorityBFS)
     if p1.bound < p2.bound
         return true
     elseif p1.bound == p2.bound
-        return p1.depth < p2.depth
+        if p1.depth < p2.depth
+            return true
+        elseif p1.depth == p2.depth
+            return p1.neg_idx < p2.neg_idx
+        else
+            return false
+        end
     end
     return false
 end

--- a/src/types.jl
+++ b/src/types.jl
@@ -93,6 +93,40 @@ end
 Base.copy(N::NotEqualTo) = NotEqualTo(N.value)
 
 #====================================================================================
+====================== TYPES FOR TRAVERSING ========================================
+====================================================================================#
+
+abstract type Priority end
+
+struct PriorityDFS{T<:Real} <: Priority
+    depth::Int
+    bound::T
+end
+
+function Base.isless(p1::PriorityDFS, p2::PriorityDFS)
+    if p1.depth < p2.depth
+        return true
+    elseif p1.depth == p2.depth
+        return p1.bound < p2.bound
+    end
+    return false
+end
+
+struct PriorityBFS{T<:Real} <: Priority
+    bound::T
+    depth::Int
+end
+
+function Base.isless(p1::PriorityBFS, p2::PriorityBFS)
+    if p1.bound < p2.bound
+        return true
+    elseif p1.bound == p2.bound
+        return p1.depth < p2.depth
+    end
+    return false
+end
+
+#====================================================================================
 ====================== TYPES FOR CONSTRAINTS ========================================
 ====================================================================================#
 
@@ -379,6 +413,7 @@ mutable struct ConstraintSolverModel{T<:Real}
     bt_infeasible::Vector{Int}
     c_backtrack_idx::Int
     backtrack_vec::Vector{BacktrackObj{T}}
+    backtrack_pq::PriorityQueue
     sense::MOI.OptimizationSense
     objective::ObjectiveFunction
     var_in_obj::Vector{Bool} # saves whether a variable is part of the objective function

--- a/test/constraints/equal_to.jl
+++ b/test/constraints/equal_to.jl
@@ -1,0 +1,43 @@
+@testset "EqualTo Constraint" begin
+@testset "digits form a number (Issue 200)" begin
+    use_diff  = false
+    model = Model(optimizer_with_attributes(CS.Optimizer,
+                                                            "traverse_strategy" => :DBFS,
+                                                            "branch_split" => :InHalf,
+                                                            "logging" => []
+                                        ))
+
+    @variable(model, 0 <= x[1:10] <= 9, Int)
+    @variable(model, 10000 <= v[1:2] <= 99999, Int) # ABCDE and FGHIJ
+    if use_diff
+        @variable(model, 0 <= diff <= 999, Int) # adding this is much slower than using v[1:2] only
+    end
+
+    a,b,c,d,e,f,g,h,i,j = x
+    @constraint(model, x in CS.AllDifferentSet())
+    @constraint(model, v[1] == 10000*a + 1000*b + 100*c + 10*d + e) # ABCDE
+    @constraint(model, v[2] == 10000*f + 1000*g + 100*h + 10*i + j) # FGHIJ
+
+    # Using diff is slower
+    if use_diff
+        @constraint(model, diff == v[1] - v[2])  # much slower
+        @constraint(model, diff >= 1)
+    else
+        @constraint(model, v[1] - v[2] >= 1)
+    end
+
+    if use_diff
+        @objective(model, Min, diff) # slower
+    else
+        @objective(model, Min, v[1]-v[2])
+    end
+
+    # Solve the problem
+    optimize!(model)
+
+    status = JuMP.termination_status(model)
+    @test status == MOI.OPTIMAL
+    x_vals = convert.(Int, JuMP.value.(x))
+    @test x_vals == [5, 0, 1, 2, 3, 4, 9, 8, 7, 6]
+end
+end

--- a/test/fcts.jl
+++ b/test/fcts.jl
@@ -496,8 +496,8 @@
         com.traverse_strategy = Val(:DFS)
         com.sense = MOI.MIN_SENSE
         com.backtrack_vec = Vector{CS.BacktrackObj{Float64}}()
-        bounds = [0.4, 0.15, 0.15, 0.1]
-        depths = [3, 2, 1, 2]
+        bounds = [0.4, 0.15, 0.15, 0.1, 0.1]
+        depths = [3, 2, 1, 2, 2]
         bo = CS.BacktrackObj(com)
         for i = 1:length(bounds)
             bo.status = :Open
@@ -507,7 +507,7 @@
             push!(com.backtrack_vec, bo)
             CS.add2priorityqueue(com, com.backtrack_vec[end])
         end
-        order = [1,4,2,3]
+        order = [1,4,5,2,3]
         for i=1:length(bounds)
             found, bo = CS.get_next_node(com, com.backtrack_vec, true)
             @test found 
@@ -520,11 +520,8 @@
         com.options.traverse_strategy = :BFS
         com.sense = MOI.MIN_SENSE
         com.backtrack_vec = Vector{CS.BacktrackObj{Float64}}()
-        bounds = [0.4, 0.15, 0.15, 0.1]
-        depths = [3, 2, 1, 2]
-        bo = CS.BacktrackObj(com)
-        bounds = [0.4, 0.15, 0.15, 0.1]
-        depths = [3, 2, 1, 2]
+        bounds = [0.4, 0.15, 0.15, 0.1, 0.1]
+        depths = [3, 2, 1, 2, 2]
         bo = CS.BacktrackObj(com)
         for i = 1:length(bounds)
             bo.status = :Open
@@ -535,7 +532,7 @@
             CS.add2priorityqueue(com, com.backtrack_vec[end])
         end
 
-        order = [4,2,3,1]
+        order = [4,5,2,3,1]
         for i=1:length(bounds)
             found, bo = CS.get_next_node(com, com.backtrack_vec, true)
             @test found 

--- a/test/fcts.jl
+++ b/test/fcts.jl
@@ -492,9 +492,10 @@
 
     @testset "Traverse" begin
         com = CS.ConstraintSolverModel()
+        com.options.traverse_strategy = :DFS
         com.traverse_strategy = Val(:DFS)
         com.sense = MOI.MIN_SENSE
-        backtrack_vec = Vector{CS.BacktrackObj{Float64}}()
+        com.backtrack_vec = Vector{CS.BacktrackObj{Float64}}()
         bounds = [0.4, 0.15, 0.15, 0.1]
         depths = [3, 2, 1, 2]
         bo = CS.BacktrackObj(com)
@@ -503,24 +504,40 @@
             bo.idx = i
             bo.best_bound = bounds[i]
             bo.depth = depths[i]
-            push!(backtrack_vec, bo)
+            push!(com.backtrack_vec, bo)
+            CS.add2priorityqueue(com, com.backtrack_vec[end])
         end
         order = [1,4,2,3]
         for i=1:length(bounds)
-            found, bo = CS.get_next_node(com, backtrack_vec, true)
+            found, bo = CS.get_next_node(com, com.backtrack_vec, true)
             @test found 
             @test bo.idx == order[i]
-            bo.status = :Closed
+            CS.close_node!(com, bo.idx)
         end
 
-        # test Best first search
+        com = CS.ConstraintSolverModel()
         com.traverse_strategy = Val(:BFS)
-        for i=1:length(bounds)
-            backtrack_vec[i].status = :Open
+        com.options.traverse_strategy = :BFS
+        com.sense = MOI.MIN_SENSE
+        com.backtrack_vec = Vector{CS.BacktrackObj{Float64}}()
+        bounds = [0.4, 0.15, 0.15, 0.1]
+        depths = [3, 2, 1, 2]
+        bo = CS.BacktrackObj(com)
+        bounds = [0.4, 0.15, 0.15, 0.1]
+        depths = [3, 2, 1, 2]
+        bo = CS.BacktrackObj(com)
+        for i = 1:length(bounds)
+            bo.status = :Open
+            bo.idx = i
+            bo.best_bound = bounds[i]
+            bo.depth = depths[i]
+            push!(com.backtrack_vec, bo)
+            CS.add2priorityqueue(com, com.backtrack_vec[end])
         end
+
         order = [4,2,3,1]
         for i=1:length(bounds)
-            found, bo = CS.get_next_node(com, backtrack_vec, true)
+            found, bo = CS.get_next_node(com, com.backtrack_vec, true)
             @test found 
             @test bo.idx == order[i]
             bo.status = :Closed

--- a/test/general.jl
+++ b/test/general.jl
@@ -30,7 +30,7 @@ function general_tree_test(com::CS.CoM)
             next_idx = rand(2:n_backtracks)
             status = com.logs[next_idx].status
         end
-        
+        println("next_idx: $next_idx")
         CS.checkout_from_to!(com, c_backtrack_idx, next_idx)
 
         if com.backtrack_vec[next_idx].parent_idx != 0
@@ -55,6 +55,7 @@ function general_tree_test(com::CS.CoM)
         end
 
         c_backtrack_idx = next_idx
+        @show [values(var) for var in com.search_space]
     
         # if it has children
         if length(com.logs[c_backtrack_idx].children) > 0 && n_children_tests < 5
@@ -75,6 +76,7 @@ function general_tree_test(com::CS.CoM)
                 @assert feasible
                 @assert further_pruning
             end
+            @show [values(var) for var in com.search_space]
             
             @assert CS.prune!(com)
             CS.call_finished_pruning!(com)

--- a/test/general.jl
+++ b/test/general.jl
@@ -30,7 +30,6 @@ function general_tree_test(com::CS.CoM)
             next_idx = rand(2:n_backtracks)
             status = com.logs[next_idx].status
         end
-        println("next_idx: $next_idx")
         CS.checkout_from_to!(com, c_backtrack_idx, next_idx)
 
         if com.backtrack_vec[next_idx].parent_idx != 0
@@ -55,7 +54,6 @@ function general_tree_test(com::CS.CoM)
         end
 
         c_backtrack_idx = next_idx
-        @show [values(var) for var in com.search_space]
     
         # if it has children
         if length(com.logs[c_backtrack_idx].children) > 0 && n_children_tests < 5
@@ -74,9 +72,7 @@ function general_tree_test(com::CS.CoM)
                 constraints = com.constraints[com.subscription[var_idx]]
                 feasible, further_pruning = CS.update_best_bound!(com.backtrack_vec[c_backtrack_idx], com, constraints)
                 @assert feasible
-                @assert further_pruning
             end
-            @show [values(var) for var in com.search_space]
             
             @assert CS.prune!(com)
             CS.call_finished_pruning!(com)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -48,6 +48,7 @@ include("moi.jl")
 include("constraints/table.jl")
 include("constraints/indicator.jl")
 include("constraints/reified.jl")
+include("constraints/equal_to.jl")
 
 include("lp_solver.jl")
 


### PR DESCRIPTION
Implementation of #194 + removing further pruning for the following reasons:

A node that was stopped because of further pruning still creates two children even though it might be infeasible. Additionally pruning has to be done at a later step in both children which potentially increases running time.
