### PR TITLE
Bugfix for reified constraint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 - Using faster version of strongly connected components with lower memory footprint
+- Bugfix in reified constraint:
+  - If inner constraint can't be activated it shouldn't be solved
+    - Bug found by @hakank see [Issue #202](https://github.com/Wikunia/ConstraintSolver.jl/issues/202)
 
 ## v0.4.0 (29th of November 2020)
 **Improvements for graph coloring**

--- a/src/constraints/reified.jl
+++ b/src/constraints/reified.jl
@@ -27,9 +27,10 @@ function prune_constraint!(
     logs = true
 ) where {A, T<:Real, RS<:ReifiedSet{A}}
     # 1. if the inner constraint is solved then the reified variable can be set to activate_on
-    # 2. if the reified constraint is active then prune can be called for the inner constraint
-    # 3. if the reified constraint is fixed to inactive one would need to "anti" prune which is currently not possible
-    
+    # 2. if the inner constraint is ant-solved (all fixed but don't fulfill) the reified variable can be set to !activate_on
+    # 3. if the reified constraint is active then prune can be called for the inner constraint
+    # 4. if the reified constraint is fixed to inactive one would need to "anti" prune which is currently not possible
+
     variables = com.search_space
     rei_vidx = constraint.indices[1]
     inner_constraint = constraint.inner_constraint
@@ -39,6 +40,9 @@ function prune_constraint!(
     if is_solved_constraint(com, inner_constraint, inner_constraint.fct, inner_constraint.set)
         !fix!(com, variables[rei_vidx], activate_on) && return false
     #2
+    elseif issetto(variables[rei_vidx], activate_on)
+        return prune_constraint!(com, inner_constraint, inner_constraint.fct, inner_constraint.set)
+    # 3
     elseif issetto(variables[rei_vidx], activate_on)
         return prune_constraint!(com, inner_constraint, inner_constraint.fct, inner_constraint.set)
     end
@@ -57,8 +61,17 @@ function still_feasible(
     variables = com.search_space
     activate_on = Int(constraint.activate_on)
     rei_vidx = constraint.indices[1]
+    # if currently activated check if inner constraint is feasible
     if (vidx == rei_vidx && val == activate_on) || issetto(variables[rei_vidx], activate_on)
         return still_feasible(com, inner_constraint, inner_constraint.fct, inner_constraint.set, vidx, val)
+    end
+    # if inner constraint is not activated it shouldn't be solved
+    if all(i == vidx || isfixed(com.search_space[i]) for i in inner_constraint.indices)
+        # if rei_vidx can't be activated:
+        if !has(variables[rei_vidx], activate_on)
+            values = [i == vidx ? val : value(com.search_space[i]) for i in inner_constraint.indices]
+            return !is_solved_constraint(inner_constraint, inner_constraint.fct, inner_constraint.set, values)
+        end
     end
     return true
 end
@@ -87,7 +100,7 @@ function update_best_bound_constraint!(com::CS.CoM,
     search_space = com.search_space
     reified_var = search_space[reified_vidx]
     if inner_constraint.impl.update_best_bound
-        if CS.issetto(reified_var, Int(constraint.activate_on)) 
+        if CS.issetto(reified_var, Int(constraint.activate_on))
             return update_best_bound_constraint!(com, inner_constraint, inner_constraint.fct, inner_constraint.set, vidx, lb, ub)
         else
             # if not activated (for example in a different subtree) we reset the bounds


### PR DESCRIPTION
Solved #202 

There were some pruning possibilities missing in the reified constraint as well as an error in how `still_feasible` was implemented.

In particular the following things were added:
- if inner constraint can't be activated it shouldn't be solved
- if the inner constraint is anti-solved (all fixed but don't fulfill) the reified variable can be set to !activate_on
