### PR TITLE
Bugfix simplify

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
 # ConstrainSolver.jl - Changelog
 
 ## Unreleased 
+- **Dropped support for Julia v1.0 and v1.1**
 - Throw error if there is a dimension mismatch in a `TableSet`
-- Dropped support for Julia v1.0 and v1.1
+- Bugfix in `simplify!` check that one inner index isn't used more than once
 
 ## v0.5.3 (12th of December 2020)
 - Bugfix for optimization with reified and indicator constraints

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ConstraintSolver"
 uuid = "e0e52ebd-5523-408d-9ca3-7641f1cd1405"
 authors = ["Ole Kröger <o.kroeger@opensourc.es>"]
-version = "0.5.3"
+version = "0.6.0"
 
 [deps]
 DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"

--- a/src/simplify.jl
+++ b/src/simplify.jl
@@ -241,7 +241,7 @@ function simplify_all_different_inner_equal_to(com, constraint::AllDifferentCons
     @assert length(constraint.indices) == length(constraint.pvals)
     added_constraint_idxs = Int[]
     # make sure that we don't use an index more than once
-    used_indices = falses(maximum(constraint.indices))
+    used_indices = falses(length(com.search_space))
     # we don't try to maximize the sum here so one might be able to use
     # a different constraint to start with to get a better sum.
     all_diff_sum = sum(constraint.pvals)
@@ -257,8 +257,8 @@ function simplify_all_different_inner_equal_to(com, constraint::AllDifferentCons
             if all(t.coefficient == 1 for t in sub_constraint.fct.terms)
                 # only use constraint if none of the indices was already used for
                 # computing the inner sum
-                if !any(used_indices[constraint.indices])
-                    used_indices[constraint.indices] .= true
+                if !any(used_indices[sub_constraint.indices])
+                    used_indices[sub_constraint.indices] .= true
                     # compute sum inside all sum constraints
                     found_possible_constraint = true
                     in_sum += sub_constraint.set.value - sub_constraint.fct.constant

--- a/src/simplify.jl
+++ b/src/simplify.jl
@@ -240,6 +240,10 @@ This function checks all sum constraints which are completely inside of the alld
 function simplify_all_different_inner_equal_to(com, constraint::AllDifferentConstraint)
     @assert length(constraint.indices) == length(constraint.pvals)
     added_constraint_idxs = Int[]
+    # make sure that we don't use an index more than once
+    used_indices = falses(maximum(constraint.indices))
+    # we don't try to maximize the sum here so one might be able to use
+    # a different constraint to start with to get a better sum.
     all_diff_sum = sum(constraint.pvals)
     in_sum = 0
     found_possible_constraint = false
@@ -251,11 +255,16 @@ function simplify_all_different_inner_equal_to(com, constraint::AllDifferentCons
         if isa(sub_constraint.fct, SAF) && isa(sub_constraint.set, MOI.EqualTo)
             # the coefficients must be all 1
             if all(t.coefficient == 1 for t in sub_constraint.fct.terms)
-                # compute sum inside all sum constraints
-                found_possible_constraint = true
-                in_sum += sub_constraint.set.value - sub_constraint.fct.constant
-                # for sum which are in alldifferent but not in sum constraints
-                outside_indices = setdiff(outside_indices, sub_constraint.indices)
+                # only use constraint if none of the indices was already used for
+                # computing the inner sum
+                if !any(used_indices[constraint.indices])
+                    used_indices[constraint.indices] .= true
+                    # compute sum inside all sum constraints
+                    found_possible_constraint = true
+                    in_sum += sub_constraint.set.value - sub_constraint.fct.constant
+                    # for sum which are in alldifferent but not in sum constraints
+                    outside_indices = setdiff(outside_indices, sub_constraint.indices)
+                end
             end
         end
     end


### PR DESCRIPTION
Fixes #226 

Fixes a bug in `simplify` which creates additional `==` constraints when both `==` and alldifferent are active.
In this case indices were used more than once to calculate the inner sum.
