### PR TITLE
check not only for no variable but also for coefficient 0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # ConstrainSolver.jl - Changelog
 
+## Unreleased
+- Bugfix when linear constraint has only variables with coefficient 0 like `x <= x` => `0x <= 0`
+
 ## v0.6.1 (15th of January 2021)
 - Bugfix if binary variable is constrained directly in `@variable`
 - Use `CS.get_inner_model` to get the `ConstraintSolverModel`

--- a/src/MOI_wrapper/constraints.jl
+++ b/src/MOI_wrapper/constraints.jl
@@ -151,11 +151,18 @@ Create a new linear constraint and return a `LinearConstraint` with already a co
 such that it can be simply added with [`add_constraint!`](@ref)
 """
 function new_linear_constraint(model::Optimizer, func::SAF{T}, set) where {T<:Real}
+    func = remove_zero_coeff(func)
+
     indices = [v.variable_index.value for v in func.terms]
 
     lc_idx = length(model.inner.constraints) + 1
     lc = LinearConstraint(lc_idx, func, set, indices)
     return lc
+end
+
+function remove_zero_coeff(func::MOI.ScalarAffineFunction)
+    terms = [term for term in func.terms if term.coefficient != 0]
+    return MOI.ScalarAffineFunction(terms, func.constant)
 end
 
 """

--- a/src/constraints/linear_constraints.jl
+++ b/src/constraints/linear_constraints.jl
@@ -83,7 +83,7 @@ function init_constraint!(
     constraint.rhs = get_rhs_from_strictly(com, constraint, fct, set)
     constraint.strict_rhs = set.set.upper - fct.constant
     constraint.is_strict = true
-    length(constraint.indices) == 0 && return fct.constant < set.set.upper
+    is_no_variable_constraint(constraint) && return fct.constant < set.set.upper
 
     return true
 end
@@ -103,9 +103,9 @@ function init_constraint!(
     active = true,
 ) where {T<:Real}
     constraint.rhs = set.upper - fct.constant
-    length(constraint.indices) > 0 && return true
+    is_no_variable_constraint(constraint) && return fct.constant <= set.upper
 
-    return fct.constant <= set.upper
+    return true
 end
 
 function init_constraint!(
@@ -116,9 +116,9 @@ function init_constraint!(
     active = true,
 ) where {T<:Real}
     constraint.rhs = set.value - fct.constant
-    length(constraint.indices) > 0 && return true
+    is_no_variable_constraint(constraint) && return fct.constant == set.value
 
-    return fct.constant == set.value
+    return true
 end
 
 """

--- a/src/util.jl
+++ b/src/util.jl
@@ -157,8 +157,9 @@ end
     end
 end
 
-
+"""
+    Return whether the given LinearConstraint doesn't contain any variables i.e for 0 <= 0
+"""
 function is_no_variable_constraint(constraint::LinearConstraint)
-    length(constraint.indices) == 0 && return true
-    return all(term.coefficient == 0 for term in constraint.fct.terms)
+    return length(constraint.indices) == 0
 end

--- a/src/util.jl
+++ b/src/util.jl
@@ -156,3 +156,9 @@ end
         Core.setproperty!(c, s, v)
     end
 end
+
+
+function is_no_variable_constraint(constraint::LinearConstraint)
+    length(constraint.indices) == 0 && return true
+    return all(term.coefficient == 0 for term in constraint.fct.terms)
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,6 +4,7 @@ using JSON
 using Random
 using MathOptInterface, JuMP, Cbc, GLPK, Combinatorics
 using ReferenceTests
+using LinearAlgebra
 
 const MOI = MathOptInterface
 const CS = ConstraintSolver

--- a/test/unit/constraints/equal_to.jl
+++ b/test/unit/constraints/equal_to.jl
@@ -164,13 +164,13 @@ end
 @testset "constraint without variables" begin
     m = Model(optimizer_with_attributes(CS.Optimizer, "logging" => []))
     @variable(m, -5 <= x[1:2] <= 5, Int)
-    @constraint(m, sum(0 .* x) == 10)
+    @constraint(m, x[2] - x[1] + (-x[2]) + x[1] == 10)
     optimize!(m)
     @test JuMP.termination_status(m) == MOI.INFEASIBLE
 
     m = Model(optimizer_with_attributes(CS.Optimizer, "logging" => []))
     @variable(m, -5 <= x[1:2] <= 5, Int)
-    @constraint(m, sum(0 .* x) == 0)
+    @constraint(m, x[2] - x[1] + (-x[2]) + x[1] == 0)
     optimize!(m)
     @test JuMP.termination_status(m) == MOI.OPTIMAL
 end

--- a/test/unit/constraints/equal_to.jl
+++ b/test/unit/constraints/equal_to.jl
@@ -160,3 +160,17 @@ end
     @test CS.fix!(com, variables[2], 5; check_feasibility = false)
     @test !CS.is_constraint_violated(com, constraint, constraint.fct, constraint.set)
 end
+
+@testset "constraint without variables" begin
+    m = Model(optimizer_with_attributes(CS.Optimizer, "logging" => []))
+    @variable(m, -5 <= x[1:2] <= 5, Int)
+    @constraint(m, sum(0 .* x) == 10)
+    optimize!(m)
+    @test JuMP.termination_status(m) == MOI.INFEASIBLE
+
+    m = Model(optimizer_with_attributes(CS.Optimizer, "logging" => []))
+    @variable(m, -5 <= x[1:2] <= 5, Int)
+    @constraint(m, sum(0 .* x) == 0)
+    optimize!(m)
+    @test JuMP.termination_status(m) == MOI.OPTIMAL
+end

--- a/test/unit/constraints/less_than.jl
+++ b/test/unit/constraints/less_than.jl
@@ -111,13 +111,13 @@ end
 @testset "constraint without variables" begin
     m = Model(optimizer_with_attributes(CS.Optimizer, "logging" => []))
     @variable(m, -5 <= x[1:2] <= 5, Int)
-    @constraint(m, sum(0 .* x) >= 10)
+    @constraint(m, x[2] - x[1] >= x[2]-x[1] + 10)
     optimize!(m)
     @test JuMP.termination_status(m) == MOI.INFEASIBLE
 
     m = Model(optimizer_with_attributes(CS.Optimizer, "logging" => []))
     @variable(m, -5 <= x[1:2] <= 5, Int)
-    @constraint(m, sum(0 .* x) <= 0)
+    @constraint(m, x[2] - x[1] + (-x[2]) + x[1] <= 0)
     optimize!(m)
     @test JuMP.termination_status(m) == MOI.OPTIMAL
 

--- a/test/unit/constraints/less_than.jl
+++ b/test/unit/constraints/less_than.jl
@@ -107,3 +107,23 @@ end
     @test CS.fix!(com, variables[constraint.indices[1]], 5; check_feasibility = false)
     @test !CS.is_constraint_violated(com, constraint, constraint.fct, constraint.set)
 end
+
+@testset "constraint without variables" begin
+    m = Model(optimizer_with_attributes(CS.Optimizer, "logging" => []))
+    @variable(m, -5 <= x[1:2] <= 5, Int)
+    @constraint(m, sum(0 .* x) >= 10)
+    optimize!(m)
+    @test JuMP.termination_status(m) == MOI.INFEASIBLE
+
+    m = Model(optimizer_with_attributes(CS.Optimizer, "logging" => []))
+    @variable(m, -5 <= x[1:2] <= 5, Int)
+    @constraint(m, sum(0 .* x) <= 0)
+    optimize!(m)
+    @test JuMP.termination_status(m) == MOI.OPTIMAL
+
+    m = Model(optimizer_with_attributes(CS.Optimizer, "logging" => []))
+    @variable(m, -5 <= x[1:2] <= 5, Int)
+    @constraint(m, sum(0 .* x) <= 1)
+    optimize!(m)
+    @test JuMP.termination_status(m) == MOI.OPTIMAL
+end

--- a/test/unit/constraints/strictly_less_than.jl
+++ b/test/unit/constraints/strictly_less_than.jl
@@ -297,13 +297,13 @@ end
 @testset "constraint without variables" begin
     m = Model(optimizer_with_attributes(CS.Optimizer, "logging" => []))
     @variable(m, -5 <= x[1:2] <= 5, Int)
-    @constraint(m, sum(0 .* x) > 10)
+    @constraint(m, x[2] - x[1] > -x[1] + x[2])
     optimize!(m)
     @test JuMP.termination_status(m) == MOI.INFEASIBLE
 
     m = Model(optimizer_with_attributes(CS.Optimizer, "logging" => []))
     @variable(m, -5 <= x[1:2] <= 5, Int)
-    @constraint(m, sum(0 .* x) < 0.001)
+    @constraint(m, x[1] - x[2] + (-x[1]) + x[2] < 0.001)
     optimize!(m)
     @test JuMP.termination_status(m) == MOI.OPTIMAL
 end


### PR DESCRIPTION
Fix for #239 

This makes sure that even if a variable exist like in the case `0x <= -1` it get's checked as `0 <= -1` as done with constraints without a variable. Basically it checks for no variables or whether all variables have coefficient 0. 