### PR TITLE
Some general performance updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
  
 ## Unreleased
 - Bugfix in reified `still_feasible` when setting to inactive
+- Some general performance updates [PR #247](https://github.com/Wikunia/ConstraintSolver.jl/pull/247)
 
 ## v0.6.3 (17th of January 2021)
 - Use anti pruning in reified constraints 

--- a/src/ConstraintSolver.jl
+++ b/src/ConstraintSolver.jl
@@ -92,8 +92,9 @@ function fulfills_constraints(com::CS.CoM, vidx, value)
         return true
     end
     feasible = true
+    constraints =  com.constraints
     for ci in com.subscription[vidx]
-        constraint = com.constraints[ci]
+        constraint = constraints[ci]
         # only call if the function got initialized already
         if constraint.is_initialized
             feasible =
@@ -466,8 +467,9 @@ function solve_with_backtrack!(com, max_bt_steps; sorting = true)
         log_table = true
     end
 
+    check_bounds = com.sense != MOI.FEASIBILITY_SENSE
     status, last_backtrack_id =
-        backtrack!(com, max_bt_steps; sorting = sorting, log_table = log_table)
+        backtrack!(com, max_bt_steps; sorting = sorting, log_table = log_table, check_bounds = check_bounds)
 
     status != :TBD && return status
 

--- a/src/constraints/linear_constraints.jl
+++ b/src/constraints/linear_constraints.jl
@@ -527,10 +527,7 @@ function is_constraint_solved(
     set::MOI.EqualTo{T},
     values::Vector{Int},
 ) where {T<:Real}
-
-    indices = [t.variable_index.value for t in fct.terms]
-    coeffs = [t.coefficient for t in fct.terms]
-    return sum(values .* coeffs) + fct.constant ≈ set.value
+    return sum(values .* constraint.coeffs) + fct.constant ≈ set.value
 end
 
 function is_constraint_solved(
@@ -539,10 +536,7 @@ function is_constraint_solved(
     set::MOI.LessThan{T},
     values::Vector{Int},
 ) where {T<:Real}
-
-    indices = [t.variable_index.value for t in fct.terms]
-    coeffs = [t.coefficient for t in fct.terms]
-    return sum(values .* coeffs) + fct.constant <= set.upper
+    return sum(values .* constraint.coeffs) + fct.constant <= set.upper
 end
 
 
@@ -552,10 +546,7 @@ function is_constraint_solved(
     set::Strictly{T, MOI.LessThan{T}},
     values::Vector{Int},
 ) where {T<:Real}
-
-    indices = [t.variable_index.value for t in fct.terms]
-    coeffs = [t.coefficient for t in fct.terms]
-    return sum(values .* coeffs) + fct.constant < set.set.upper
+    return sum(values .* constraint.coeffs) + fct.constant < set.set.upper
 end
 
 
@@ -581,7 +572,7 @@ function is_constraint_violated(
             constraint,
             fct,
             set,
-            [CS.value(var) for var in com.search_space[constraint.indices]],
+            CS.value.(com.search_space[constraint.indices]),
         )
     end
     return false

--- a/src/objective.jl
+++ b/src/objective.jl
@@ -4,17 +4,17 @@
 Iterate over all backtrack objects to set the new best bound for the whole search tree
 """
 function update_best_bound!(com::CS.CoM)
-    if any(bo -> bo.status == :Open, com.backtrack_vec)
+    if !isempty(com.backtrack_pq)
         if com.sense == MOI.MIN_SENSE
             max_val = typemax(com.best_bound)
-            com.best_bound = minimum([
+            com.best_bound = minimum(
                 bo.status == :Open ? bo.best_bound : max_val for bo in com.backtrack_vec
-            ])
+            )
         elseif com.sense == MOI.MAX_SENSE
             min_val = typemin(com.best_bound)
-            com.best_bound = maximum([
+            com.best_bound = maximum(
                 bo.status == :Open ? bo.best_bound : min_val for bo in com.backtrack_vec
-            ])
+            )
         end # otherwise no update is needed
     end
 end

--- a/src/pruning.jl
+++ b/src/pruning.jl
@@ -205,17 +205,20 @@ Reverse the changes made by a specific backtrack object
 function reverse_pruning!(com::CS.CoM, backtrack_idx::Int)
     com.c_backtrack_idx = backtrack_idx
     search_space = com.search_space
+    latest_changes = [var.changes[backtrack_idx] for var in search_space]
     for var in search_space
         v_idx = var.idx
-        for change in Iterators.reverse(var.changes[backtrack_idx])
+        for change in Iterators.reverse(latest_changes[v_idx])
             single_reverse_pruning!(search_space, v_idx, change[4], change[3])
         end
     end
+    subscriptions = com.subscription
+    constraints = com.constraints
     for var in search_space
-        length(var.changes[backtrack_idx]) == 0 && continue
-        var.idx > length(com.subscription) && continue
-        @inbounds for ci in com.subscription[var.idx]
-            constraint = com.constraints[ci]
+        length(latest_changes[var.idx]) == 0 && continue
+        var.idx > length(subscriptions) && continue
+        @inbounds for ci in subscriptions[var.idx]
+            constraint = constraints[ci]
             if constraint.impl.single_reverse_pruning
                 single_reverse_pruning_constraint!(
                     com,
@@ -228,7 +231,7 @@ function reverse_pruning!(com::CS.CoM, backtrack_idx::Int)
             end
         end
     end
-    for constraint in com.constraints
+    for constraint in constraints
         if constraint.impl.reverse_pruning
             reverse_pruning_constraint!(
                 com,

--- a/src/type_inits.jl
+++ b/src/type_inits.jl
@@ -101,6 +101,7 @@ function LinearConstraint(
         false, # the rhs is not a strong rhs yet
         zero(promote_T),
         zero(promote_T),
+        coeffs,
         mins,
         maxs,
         pre_mins,

--- a/src/types.jl
+++ b/src/types.jl
@@ -383,6 +383,7 @@ mutable struct LinearConstraint{T<:Real} <: Constraint
     # same as rhs but for `<` it saves the original value - constant
     # (rhs is then computed to be usable as <=)
     strict_rhs::T
+    coeffs::Vector{T}
     mins::Vector{T}
     maxs::Vector{T}
     pre_mins::Vector{T}


### PR DESCRIPTION
- `coeffs` inside LinearConstraint is precomputed once.
- avoid checking bounds in feasibility models
- `update_best_bound!` faster and less memory consumption