### PR TITLE
check if inner violated and not just fixed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # ConstrainSolver.jl - Changelog
  
-## Unreleased
-- set activator to false when inner violated
+## v0.6.9 (17th of July 2021)
+- set activator to false when inner violated [PR #266](https://github.com/Wikunia/ConstraintSolver.jl/pull/266)
 
 ## v0.6.8 (14th of June 2021)
 - support for xor and xnor constraints 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # ConstrainSolver.jl - Changelog
  
+## Unreleased
+- set activator to false when inner violated
+
 ## v0.6.8 (14th of June 2021)
 - support for xor and xnor constraints 
 - better bridge structure for boolean constraints

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ConstraintSolver"
 uuid = "e0e52ebd-5523-408d-9ca3-7641f1cd1405"
 authors = ["Ole Kröger <o.kroeger@opensourc.es>"]
-version = "0.6.8"
+version = "0.6.9"
 
 [deps]
 DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"

--- a/src/constraints/boolset.jl
+++ b/src/constraints/boolset.jl
@@ -298,3 +298,11 @@ function finished_pruning_constraint!(
         end
     end
 end
+
+
+function changed!(com::CS.CoM, constraint::BoolConstraint, fct, set)
+    lhs = constraint.lhs
+    changed!(com, lhs, lhs.fct, lhs.set)
+    rhs = constraint.rhs
+    changed!(com, rhs, rhs.fct, rhs.set)
+end

--- a/src/constraints/indicator.jl
+++ b/src/constraints/indicator.jl
@@ -230,3 +230,8 @@ function is_constraint_violated(
     end
     return false
 end
+
+function changed!(com::CS.CoM, constraint::IndicatorConstraint, fct, set)
+    inner_constraint = constraint.inner_constraint
+    changed!(com, inner_constraint, inner_constraint.fct, inner_constraint.set)
+end

--- a/src/constraints/reified.jl
+++ b/src/constraints/reified.jl
@@ -61,8 +61,27 @@ function prune_constraint!(
     activate_on = Int(constraint.activate_on)
     activate_off = activate_on == 1 ? 0 : 1
 
+
+    # 3
+    if issetto(variables[rei_vidx], activate_on)
+        !activate_inner!(com, constraint) && return false
+        return prune_constraint!(
+            com,
+            inner_constraint,
+            inner_constraint.fct,
+            inner_constraint.set,
+        )
+    # 4
+    elseif issetto(variables[rei_vidx], activate_off) && complement_constraint !== nothing
+        !activate_complement_inner!(com, constraint) && return false
+        return prune_constraint!(
+            com,
+            complement_constraint,
+            complement_constraint.fct,
+            complement_constraint.set,
+        )
     # 1
-    if is_constraint_solved(
+    elseif is_constraint_solved(
         com,
         inner_constraint,
         inner_constraint.fct,
@@ -77,23 +96,6 @@ function prune_constraint!(
         inner_constraint.set,
     )
         !fix!(com, variables[rei_vidx], activate_off) && return false
-        # 3
-    elseif issetto(variables[rei_vidx], activate_on)
-        !activate_inner!(com, constraint) && return false
-        return prune_constraint!(
-            com,
-            inner_constraint,
-            inner_constraint.fct,
-            inner_constraint.set,
-        )
-    elseif issetto(variables[rei_vidx], activate_off) && complement_constraint !== nothing
-        !activate_complement_inner!(com, constraint) && return false
-        return prune_constraint!(
-            com,
-            complement_constraint,
-            complement_constraint.fct,
-            complement_constraint.set,
-        )
     end
     return true
 end
@@ -203,4 +205,13 @@ function is_constraint_violated(
         )
     end
     return false
+end
+
+function changed!(com::CS.CoM, constraint::ReifiedConstraint, fct, set)
+    inner_constraint = constraint.inner_constraint
+    changed!(com, inner_constraint, inner_constraint.fct, inner_constraint.set)
+    if constraint.complement_constraint !== nothing
+        complement_constraint = constraint.complement_constraint 
+        changed!(com, complement_constraint, complement_constraint.fct, complement_constraint.set)
+    end
 end

--- a/src/constraints/reified.jl
+++ b/src/constraints/reified.jl
@@ -50,7 +50,7 @@ function prune_constraint!(
     logs = true,
 ) where {A,T<:Real,RS<:ReifiedSet{A}}
     # 1. if the inner constraint is solved then the reified variable can be set to activate_on
-    # 2. if the complement of the inner constraint is solved (all fixed but don't fulfill) the reified variable can be set to !activate_on
+    # 2. if the inner constraint is infeasible the reified variable can be set to !activate_on
     # 3. if the reified constraint is active then prune can be called for the inner constraint
     # 4. if the reified constraint is fixed to inactive one can complement prune
 
@@ -69,8 +69,13 @@ function prune_constraint!(
         inner_constraint.set,
     )
         !fix!(com, variables[rei_vidx], activate_on) && return false
-        # 2
-    elseif all(isfixed(variables[vidx]) for vidx in inner_constraint.indices)
+    # 2
+    elseif is_constraint_violated(
+        com,
+        inner_constraint,
+        inner_constraint.fct,
+        inner_constraint.set,
+    )
         !fix!(com, variables[rei_vidx], activate_off) && return false
         # 3
     elseif issetto(variables[rei_vidx], activate_on)

--- a/src/pruning.jl
+++ b/src/pruning.jl
@@ -72,6 +72,7 @@ function prune!(
                 inner_constraint = com.constraints[ci]
                 constraint_idxs_vec[inner_constraint.idx] =
                     open_possibilities(search_space, inner_constraint.indices)
+                    changed!(com, inner_constraint, inner_constraint.fct, inner_constraint.set)
             end
         end
     end
@@ -123,6 +124,7 @@ function prune!(
                         end
                         constraint_idxs_vec[inner_constraint.idx] =
                             open_possibilities(search_space, inner_constraint.indices)
+                        changed!(com, inner_constraint, inner_constraint.fct, inner_constraint.set)
                     end
                 end
             end

--- a/src/util.jl
+++ b/src/util.jl
@@ -371,3 +371,7 @@ function view_changes(v::Variable, step_nr::Int)
     idx_end = v.changes.indices[step_nr+1]-1
     return @views v.changes.changes[idx_begin:idx_end]
 end
+
+function changed!(com::CS.CoM, constraint::Constraint, fct, set)
+    return 
+end

--- a/test/unit/constraints/and.jl
+++ b/test/unit/constraints/and.jl
@@ -162,6 +162,7 @@ end
 
     constr_indices = constraint.indices
     @test CS.fix!(com, variables[constraint.indices[3]], 0; check_feasibility = false)
+    CS.changed!(com, constraint, constraint.fct, constraint.set)
     @test !CS.prune_constraint!(com, constraint, constraint.fct, constraint.set)
 end
 

--- a/test/unit/constraints/complement.jl
+++ b/test/unit/constraints/complement.jl
@@ -9,6 +9,7 @@
     constraint = com.constraints[1]
     @test CS.fix!(com, variables[constraint.indices[1]], 1; check_feasibility = false)
     @test CS.fix!(com, variables[constraint.indices[2]], 2; check_feasibility = false)
+    CS.changed!(com, constraint, constraint.fct, constraint.set)
     @test CS.is_constraint_solved(com, constraint, constraint.fct, constraint.set)
 
     #################
@@ -23,6 +24,7 @@
     constraint = com.constraints[1]
     @test CS.fix!(com, variables[constraint.indices[1]], 1; check_feasibility = false)
     @test CS.fix!(com, variables[constraint.indices[2]], 1; check_feasibility = false)
+    CS.changed!(com, constraint, constraint.fct, constraint.set)
     @test CS.is_constraint_solved(com, constraint, constraint.fct, constraint.set)
 
     #################
@@ -39,6 +41,7 @@
     xor_constraint = com.constraints[1].inner_constraint
     @test CS.fix!(com, variables[xor_constraint.indices[1]], 0; check_feasibility = false)
     @test CS.fix!(com, variables[xor_constraint.indices[2]], 2; check_feasibility = false)
+    CS.changed!(com, xor_constraint, xor_constraint.fct, xor_constraint.set)
     @test CS.is_constraint_solved(com, xor_constraint, xor_constraint.fct, xor_constraint.set)
 
     #################
@@ -55,6 +58,7 @@
     xor_constraint = com.constraints[1].inner_constraint
     @test CS.fix!(com, variables[xor_constraint.indices[1]], 0; check_feasibility = false)
     @test CS.fix!(com, variables[xor_constraint.indices[2]], 2; check_feasibility = false)
+    CS.changed!(com, xor_constraint, xor_constraint.fct, xor_constraint.set)
     @test CS.is_constraint_solved(com, xor_constraint, xor_constraint.fct, xor_constraint.set)
 
 

--- a/test/unit/constraints/less_than.jl
+++ b/test/unit/constraints/less_than.jl
@@ -73,6 +73,7 @@
     @test sort(CS.values(com.search_space[3])) == -4:5
 
     @test CS.fix!(com, com.search_space[constr_indices[3]], -4)
+    CS.changed!(com, constraint, constraint.fct, constraint.set)
     @test CS.prune_constraint!(com, constraint, constraint.fct, constraint.set)
     @test CS.value(com.search_space[1]) == -1
     @test CS.value(com.search_space[2]) == -1

--- a/test/unit/constraints/or.jl
+++ b/test/unit/constraints/or.jl
@@ -165,6 +165,7 @@ end
 
     constr_indices = constraint.indices
     @test CS.fix!(com, variables[constraint.indices[2]], 0; check_feasibility = false)
+    CS.changed!(com, constraint, constraint.fct, constraint.set)
     @test CS.prune_constraint!(com, constraint, constraint.fct, constraint.set)
     for v in 0:2
         @test !CS.has(variables[constraint.indices[3]], v)
@@ -184,6 +185,7 @@ end
 
     constr_indices = constraint.indices
     @test CS.fix!(com, variables[constraint.indices[2]], 0; check_feasibility = false)
+    CS.changed!(com, constraint, constraint.fct, constraint.set)
     @test CS.prune_constraint!(com, constraint, constraint.fct, constraint.set)
     for v in 0:2
         @test !CS.has(variables[constraint.indices[4]], v)

--- a/test/unit/constraints/reified.jl
+++ b/test/unit/constraints/reified.jl
@@ -254,6 +254,7 @@ end
     @test CS.fix!(com, variables[constr_indices[1]], 0; check_feasibility = false)
     @test CS.fix!(com, variables[constr_indices[2]], 0; check_feasibility = false)
     @test CS.fix!(com, variables[constr_indices[3]], 5; check_feasibility = false)
+    CS.changed!(com, constraint, constraint.fct, constraint.set)
     # should prune complement
     @test CS.prune_constraint!(com, constraint, constraint.fct, constraint.set)
 

--- a/test/unit/constraints/strictly_less_than.jl
+++ b/test/unit/constraints/strictly_less_than.jl
@@ -73,6 +73,7 @@
     @test sort(CS.values(com.search_space[3])) == -5:5 # 6 not possible
 
     @test CS.fix!(com, com.search_space[constr_indices[3]], 5)
+    CS.changed!(com, constraint, constraint.fct, constraint.set)
     @test CS.prune_constraint!(com, constraint, constraint.fct, constraint.set)
     @test CS.value(com.search_space[1]) == -1
     @test CS.value(com.search_space[2]) == -1
@@ -199,6 +200,7 @@ end
     @test sort(CS.values(com.search_space[3])) == -5:6 # -6 not possible
 
     @test CS.fix!(com, com.search_space[constr_indices[3]], -5)
+    CS.changed!(com, constraint, constraint.fct, constraint.set)
     @test CS.prune_constraint!(com, constraint, constraint.fct, constraint.set)
     @test CS.value(com.search_space[1]) == -5
     @test CS.value(com.search_space[2]) == 5

--- a/test/unit/constraints/xnor.jl
+++ b/test/unit/constraints/xnor.jl
@@ -180,6 +180,7 @@ end
 
     constr_indices = constraint.indices
     @test CS.fix!(com, variables[constraint.indices[3]], 0; check_feasibility = false)
+    CS.changed!(com, constraint, constraint.fct, constraint.set)
     @test CS.prune_constraint!(com, constraint, constraint.fct, constraint.set)
     @test sort(CS.values(m, x[1])) == [0,1,2]
 end

--- a/test/unit/constraints/xor.jl
+++ b/test/unit/constraints/xor.jl
@@ -148,6 +148,7 @@ end
     xor_constraint = com.constraints[1].inner_constraint
     @test CS.fix!(com, variables[xor_constraint.indices[1]], 0; check_feasibility = false)
     @test CS.fix!(com, variables[xor_constraint.indices[2]], 2; check_feasibility = false)
+    CS.changed!(com, xor_constraint, xor_constraint.fct, xor_constraint.set)
     @test CS.is_constraint_violated(com, xor_constraint, xor_constraint.fct, xor_constraint.set)
 
     ##################
@@ -180,6 +181,7 @@ end
 
     constr_indices = constraint.indices
     @test CS.fix!(com, variables[constraint.indices[3]], 0; check_feasibility = false)
+    CS.changed!(com, constraint, constraint.fct, constraint.set)
     @test CS.prune_constraint!(com, constraint, constraint.fct, constraint.set)
     @test sort(CS.values(m, x[1])) == [3,4,5]
 end


### PR DESCRIPTION
Somehow the activator was only set to false if the inner was fully fixed and not solved.
Now it uses the `is_constraint_violated` functionality.