### PR TITLE
removed is_activated as it's unused

### DIFF
--- a/src/constraints.jl
+++ b/src/constraints.jl
@@ -49,7 +49,6 @@ function init_constraints!(com::CS.CoM; constraints = com.constraints)
 
         feasible = activate_constraint!(com, constraint, constraint.fct, constraint.set)
         !feasible && break
-        constraint.is_activated = true
     end
     return feasible
 end

--- a/src/type_inits.jl
+++ b/src/type_inits.jl
@@ -32,7 +32,6 @@ function ConstraintInternals(cidx::Int, fct, set, indices::Vector{Int})
         Int[],
         false,
         false,
-        false,
         Vector{BoundRhsVariable}(undef, 0),
     )
 end

--- a/src/types.jl
+++ b/src/types.jl
@@ -351,7 +351,6 @@ mutable struct ConstraintInternals{
     indices::Vector{Int}
     pvals::Vector{Int}
     is_initialized::Bool
-    is_activated::Bool
     is_deactivated::Bool # can be deactivated if it's absorbed by other constraints
     bound_rhs::Vector{BoundRhsVariable}# should be set if `update_best_bound` is true
 end

--- a/src/util.jl
+++ b/src/util.jl
@@ -132,7 +132,6 @@ end
         :set,
         :pvals,
         :is_initialized,
-        :is_activated,
         :is_deactivated,
         :bound_rhs,
     )
@@ -150,7 +149,6 @@ end
         :set,
         :pvals,
         :is_initialized,
-        :is_activated,
         :is_deactivated,
         :bound_rhs,
     )
@@ -171,7 +169,6 @@ end
         :set,
         :pvals,
         :is_initialized,
-        :is_activated,
         :is_deactivated,
         :bound_rhs,
     )
@@ -196,7 +193,6 @@ end
         :set,
         :pvals,
         :is_initialized,
-        :is_activated,
         :is_deactivated,
         :bound_rhs,
     )
@@ -224,7 +220,6 @@ end
         :set,
         :pvals,
         :is_initialized,
-        :is_activated,
         :is_deactivated,
         :bound_rhs,
     )
@@ -251,7 +246,6 @@ end
         :set,
         :pvals,
         :is_initialized,
-        :is_activated,
         :is_deactivated,
         :bound_rhs,
     )
@@ -329,7 +323,6 @@ function init_and_activate_constraint!(
     !init_constraint!(com, constraint, fct, set) && return false
     constraint.is_initialized = true
     !activate_constraint!(com, constraint, fct, set) && return false
-    constraint.is_activated = true
     return true
 end
 


### PR DESCRIPTION
I was mainly confused why I have `is_activated` and `is_deactivated` inside #213 and saw that `is_activated` isn't used anymore.
This PR removes all `is_activated` as it was only set but never used somewhere.